### PR TITLE
[DI-256]: Implement random seeding in BalanceDetailGenerator

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGenerator.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGenerator.scala
@@ -24,20 +24,14 @@ import scala.util.Random
 
 trait BalanceDetailGenerator(using LocalDateExtensions):
 
-  extension (random: Random)
-    private def nextInt(range: Range): Int =
-      val start  = range.start
-      val end    = range.end
-      start + random.nextInt((end - start) + 1)
-
   def generate(nino: String): BalanceDetail =
     val random = new Random(nino.hashCode())
     val poundsToPence = BigDecimal(100)
-    val pendingDueDate   = PendingDueDate(nextDayInFuture(random.nextInt(0 to 90)))
-    val payableDueDate   = PayableDueDate(nextDayInFuture(random.nextInt(0 to 180)))
-    val overdueAmount    = OverdueAmount(BigDecimal(random.nextInt(-999 to 999)) / poundsToPence)
-    val payableAmount    = PayableAmount(BigDecimal(random.nextInt(-9999 to 9999)) / poundsToPence)
-    val pendingDueAmount = PendingDueAmount(BigDecimal(random.nextInt(-99999 to 99999)) / poundsToPence)
+    val pendingDueDate   = PendingDueDate(nextDayInFuture(random.between(0, 90)))
+    val payableDueDate   = PayableDueDate(nextDayInFuture(random.between(0, 180)))
+    val overdueAmount    = OverdueAmount(BigDecimal(random.between(-999, 999)) / poundsToPence)
+    val payableAmount    = PayableAmount(BigDecimal(random.between(-9999, 9999)) / poundsToPence)
+    val pendingDueAmount = PendingDueAmount(BigDecimal(random.between(-99999, 99999)) / poundsToPence)
     val totalBalance     = TotalBalance(payableAmount ++ pendingDueAmount ++ overdueAmount)
 
     BalanceDetail(payableAmount, payableDueDate, pendingDueAmount, pendingDueDate, overdueAmount, totalBalance)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGenerator.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGenerator.scala
@@ -25,8 +25,8 @@ import scala.util.Random
 trait BalanceDetailGenerator(using LocalDateExtensions):
 
   def generate(nino: String): BalanceDetail =
-    val random = new Random(nino.hashCode())
-    val poundsToPence = BigDecimal(100)
+    val random           = new Random(nino.hashCode())
+    val poundsToPence    = BigDecimal(100)
     val pendingDueDate   = PendingDueDate(nextDayInFuture(random.between(0, 90)))
     val payableDueDate   = PayableDueDate(nextDayInFuture(random.between(0, 180)))
     val overdueAmount    = OverdueAmount(BigDecimal(random.between(-999, 999)) / poundsToPence)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGenerator.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGenerator.scala
@@ -24,19 +24,20 @@ import scala.util.Random
 
 trait BalanceDetailGenerator(using LocalDateExtensions):
 
-  extension (range: Range)
-    private inline def random: Int =
-      val random = new Random
+  extension (random: Random)
+    private def nextInt(range: Range): Int =
       val start  = range.start
       val end    = range.end
       start + random.nextInt((end - start) + 1)
 
-  def generate: BalanceDetail =
-    val pendingDueDate   = PendingDueDate(nextDayInFuture(monthsToAdd = 3))
-    val payableDueDate   = PayableDueDate(nextDayInFuture(monthsToAdd = 6))
-    val overdueAmount    = OverdueAmount((0 to 2000).random)
-    val payableAmount    = PayableAmount((0 to 10000).random)
-    val pendingDueAmount = PendingDueAmount((0 to 5000).random)
+  def generate(nino: String): BalanceDetail =
+    val random = new Random(nino.hashCode())
+    val poundsToPence = BigDecimal(100)
+    val pendingDueDate   = PendingDueDate(nextDayInFuture(random.nextInt(0 to 90)))
+    val payableDueDate   = PayableDueDate(nextDayInFuture(random.nextInt(0 to 180)))
+    val overdueAmount    = OverdueAmount(BigDecimal(random.nextInt(-999 to 999)) / poundsToPence)
+    val payableAmount    = PayableAmount(BigDecimal(random.nextInt(-9999 to 9999)) / poundsToPence)
+    val pendingDueAmount = PendingDueAmount(BigDecimal(random.nextInt(-99999 to 99999)) / poundsToPence)
     val totalBalance     = TotalBalance(payableAmount ++ pendingDueAmount ++ overdueAmount)
 
     BalanceDetail(payableAmount, payableDueDate, pendingDueAmount, pendingDueDate, overdueAmount, totalBalance)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/service/BalanceDetailService.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/service/BalanceDetailService.scala
@@ -36,15 +36,8 @@ object BalanceDetailService extends BalanceDetailService(using BalanceDetailGene
       overdueAmount = OverdueAmount(100.03),
       totalBalance = TotalBalance(300.5)
     ),
-    "AA000000B" -> BalanceDetail(
-      payableAmount = PayableAmount(200.00),
-      payableDueDate = PayableDueDate("2024-07-20"),
-      pendingDueAmount = PendingDueAmount(200.02),
-      pendingDueDate = PendingDueDate("2024-08-20"),
-      overdueAmount = OverdueAmount(200.03),
-      totalBalance = TotalBalance(600.5)
-    ),
-    "AA000000C" -> generate,
-    "AA000000D" -> Seq.fill(2)(generate),
-    "AA000000E" -> Seq.fill(3)(generate)
+    "AA000000B" -> generate("AA000000B"),
+    "AA000000C" -> generate("AA000000C"),
+    "AA000000D" -> Seq.fill(2)(generate("AA000000D")),
+    "AA000000E" -> Seq.fill(4)(generate("AA000000E"))
   )

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/time/LocalDateExtensions.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/time/LocalDateExtensions.scala
@@ -23,9 +23,9 @@ import scala.util.Random
 
 trait LocalDateExtensions:
 
-  def nextDayInFuture(monthsToAdd: Int): LocalDate =
+  def nextDayInFuture(daysToAdd: Int): LocalDate =
     val startDate = LocalDate.now()
-    val endDate   = startDate.plusMonths(monthsToAdd)
+    val endDate   = startDate.plusDays(daysToAdd)
     val days      = DAYS.between(startDate, endDate).toInt
     startDate.plusDays(Random.nextInt(days + 1))
 

--- a/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
@@ -36,4 +36,20 @@ class BalanceControllerSpec extends AnyWordSpec with Matchers {
       status(result) shouldBe Status.OK
     }
   }
+
+  "GET /balance/AA000000B" should {
+    "return 200" in {
+      val result = controller.getBalanceByNino("AA000000B")(fakeRequest)
+      contentAsString(result) shouldBe contentAsString(controller.getBalanceByNino("AA000000B")(fakeRequest))
+      status(result) shouldBe Status.OK
+    }
+  }
+
+  "GET /balance/AA000000D" should {
+    "return 200" in {
+      val result = controller.getBalanceByNino("AA000000D")(fakeRequest)
+      contentAsString(result) shouldBe contentAsString(controller.getBalanceByNino("AA000000D")(fakeRequest))
+      status(result) shouldBe Status.OK
+    }
+  }
 }

--- a/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
@@ -41,7 +41,7 @@ class BalanceControllerSpec extends AnyWordSpec with Matchers {
     "return 200" in {
       val result = controller.getBalanceByNino("AA000000B")(fakeRequest)
       contentAsString(result) shouldBe contentAsString(controller.getBalanceByNino("AA000000B")(fakeRequest))
-      status(result) shouldBe Status.OK
+      status(result)          shouldBe Status.OK
     }
   }
 
@@ -49,7 +49,7 @@ class BalanceControllerSpec extends AnyWordSpec with Matchers {
     "return 200" in {
       val result = controller.getBalanceByNino("AA000000D")(fakeRequest)
       contentAsString(result) shouldBe contentAsString(controller.getBalanceByNino("AA000000D")(fakeRequest))
-      status(result) shouldBe Status.OK
+      status(result)          shouldBe Status.OK
     }
   }
 }


### PR DESCRIPTION
Update the BalanceDetailGenerator to use a seed based on the hash of the requested nino to ensure that the stub is idempotent. Added in some test cases to check that the stub response does not change if the nino remains the same.

Updated the random number generator to closer represent the API spec, support more granularity and larger numbers using BigDecimal. The range -99999999999.99 to 99999999999.99 has yet to be fully implemented but this is a step in the right direction.