### PR TITLE
[DI-268]: Update stub to use a seeded Random object.

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Module.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Module.scala
@@ -19,12 +19,19 @@ package uk.gov.hmrc.saliabilitiessandpitstubs.config
 import com.google.inject.AbstractModule
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.AuthorizationActionFilter
+import uk.gov.hmrc.saliabilitiessandpitstubs.generator.{BalanceDetailGenerator, DefaultBalanceDetailGenerator}
+import uk.gov.hmrc.saliabilitiessandpitstubs.service.{BalanceDetailService, DefaultBalanceDetailService}
+
+import scala.util.Random
 
 class Module extends AbstractModule {
 
   override def configure(): Unit = {
     bind(classOf[AppConfig]).asEagerSingleton()
     bind(classOf[BalanceController]).asEagerSingleton()
+    bind(classOf[BalanceDetailGenerator]).to(classOf[DefaultBalanceDetailGenerator]).asEagerSingleton()
+    bind(classOf[BalanceDetailService]).to(classOf[DefaultBalanceDetailService]).asEagerSingleton()
     bind(classOf[AuthorizationActionFilter]).toProvider(classOf[AuthActionProvider]).asEagerSingleton()
+    bind(classOf[Random]).toProvider(classOf[RandomProvider]).asEagerSingleton()
   }
 }

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Providers.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Providers.scala
@@ -17,11 +17,11 @@
 //noinspection ScalaFileName
 package uk.gov.hmrc.saliabilitiessandpitstubs.config
 
-import com.google.inject.Provider
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.{AuthorizationActionFilter, DefaultOpenAuthAction, DefaultTokenBasedAction}
 
-import javax.inject.Inject
+import javax.inject.{Inject, Provider}
 import scala.concurrent.ExecutionContext
+import scala.util.Random
 
 class AuthActionProvider @Inject() (config: AppConfig, executionContext: ExecutionContext)
     extends Provider[AuthorizationActionFilter]:
@@ -29,3 +29,6 @@ class AuthActionProvider @Inject() (config: AppConfig, executionContext: Executi
     (if config.bearerAuthorisationEnabled then classOf[DefaultTokenBasedAction] else classOf[DefaultOpenAuthAction])
       .getConstructor(classOf[ExecutionContext])
       .newInstance(executionContext)
+
+class RandomProvider @Inject() (config: AppConfig) extends Provider[Random]:
+  val get: Random = if config.randomSeed.isEmpty then Random() else Random(config.randomSeed.get)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Providers.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Providers.scala
@@ -31,4 +31,4 @@ class AuthActionProvider @Inject() (config: AppConfig, executionContext: Executi
       .newInstance(executionContext)
 
 class RandomProvider @Inject() (config: AppConfig) extends Provider[Random]:
-  val get: Random = if config.randomSeed.isEmpty then Random() else Random(config.randomSeed.get)
+  val get: Random = (config.randomSeed fold Random())(Random(_))

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
@@ -26,7 +26,8 @@ import javax.inject.Inject
 
 class BalanceController @Inject() (
   val controllerComponents: ControllerComponents,
-  auth: AuthorizationActionFilter
-) extends BalanceActions(using auth, BalanceDetailService),
+  auth: AuthorizationActionFilter,
+  service: BalanceDetailService
+) extends BalanceActions(using auth, service),
       BackendBaseController,
       Logging

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/DocumentationController.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/DocumentationController.scala
@@ -17,9 +17,10 @@
 package uk.gov.hmrc.saliabilitiessandpitstubs.controllers
 
 import controllers.Assets
-import javax.inject.{Inject, Singleton}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{Inject, Singleton}
 
 @Singleton
 class DocumentationController @Inject() (assets: Assets, cc: ControllerComponents) extends BackendController(cc) {

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGenerator.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGenerator.scala
@@ -21,24 +21,22 @@ import uk.gov.hmrc.saliabilitiessandpitstubs.time.LocalDateExtensions
 import uk.gov.hmrc.saliabilitiessandpitstubs.time.LocalDateExtensions.nextDayInFuture
 
 import scala.util.Random
+import scala.util.Random.nextInt
 
-trait BalanceDetailGenerator(using LocalDateExtensions):
+trait BalanceDetailGenerator(using date: LocalDateExtensions, random: Random):
 
   extension (range: Range)
-    private inline def random: Int =
-      val random = new Random
-      val start  = range.start
-      val end    = range.end
+    private inline def randomInt: Int =
+      val start = range.start
+      val end   = range.end
       start + random.nextInt((end - start) + 1)
 
   def generate: BalanceDetail =
-    val pendingDueDate   = PendingDueDate(nextDayInFuture(monthsToAdd = 3))
-    val payableDueDate   = PayableDueDate(nextDayInFuture(monthsToAdd = 6))
-    val overdueAmount    = OverdueAmount((0 to 2000).random)
-    val payableAmount    = PayableAmount((0 to 10000).random)
-    val pendingDueAmount = PendingDueAmount((0 to 5000).random)
+    val pendingDueDate   = PendingDueDate(date.nextDayInFuture(monthsToAdd = 3))
+    val payableDueDate   = PayableDueDate(date.nextDayInFuture(monthsToAdd = 6))
+    val overdueAmount    = OverdueAmount((0 to 2000).randomInt)
+    val payableAmount    = PayableAmount((0 to 10000).randomInt)
+    val pendingDueAmount = PendingDueAmount((0 to 5000).randomInt)
     val totalBalance     = TotalBalance(payableAmount ++ pendingDueAmount ++ overdueAmount)
 
     BalanceDetail(payableAmount, payableDueDate, pendingDueAmount, pendingDueDate, overdueAmount, totalBalance)
-
-object BalanceDetailGenerator extends BalanceDetailGenerator(using LocalDateExtensions)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGenerator.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGenerator.scala
@@ -23,20 +23,20 @@ import uk.gov.hmrc.saliabilitiessandpitstubs.time.LocalDateExtensions.nextDayInF
 import scala.util.Random
 import scala.util.Random.nextInt
 
-trait BalanceDetailGenerator(using date: LocalDateExtensions, random: Random):
+trait BalanceDetailGenerator(using LocalDateExtensions)(random: Random):
 
-  extension (range: Range)
-    private inline def randomInt: Int =
-      val start = range.start
-      val end   = range.end
-      start + random.nextInt((end - start) + 1)
+  private def randomInRange(range: Range): Int =
+    val start = Math.min(range.start, range.end)
+    val end   = Math.max(range.start, range.end)
+
+    start + random.nextInt((end - start) + 1)
 
   def generate: BalanceDetail =
-    val pendingDueDate   = PendingDueDate(date.nextDayInFuture(monthsToAdd = 3))
-    val payableDueDate   = PayableDueDate(date.nextDayInFuture(monthsToAdd = 6))
-    val overdueAmount    = OverdueAmount((0 to 2000).randomInt)
-    val payableAmount    = PayableAmount((0 to 10000).randomInt)
-    val pendingDueAmount = PendingDueAmount((0 to 5000).randomInt)
+    val pendingDueDate   = PendingDueDate(nextDayInFuture(monthsToAdd = 3))
+    val payableDueDate   = PayableDueDate(nextDayInFuture(monthsToAdd = 6))
+    val overdueAmount    = OverdueAmount(randomInRange(0 to 9999))
+    val payableAmount    = PayableAmount(randomInRange(0 to 9999))
+    val pendingDueAmount = PendingDueAmount(randomInRange(0 to 9999))
     val totalBalance     = TotalBalance(payableAmount ++ pendingDueAmount ++ overdueAmount)
 
     BalanceDetail(payableAmount, payableDueDate, pendingDueAmount, pendingDueDate, overdueAmount, totalBalance)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/package.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/package.scala
@@ -23,4 +23,4 @@ import scala.util.Random
 
 package object generator:
   case class DefaultBalanceDetailGenerator @Inject() (random: Random)
-      extends BalanceDetailGenerator(using LocalDateExtensions, random)
+      extends BalanceDetailGenerator(using LocalDateExtensions)(random)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/package.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/package.scala
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.saliabilitiessandpitstubs.config
+package uk.gov.hmrc.saliabilitiessandpitstubs
 
-import play.api.Configuration
+import uk.gov.hmrc.saliabilitiessandpitstubs.time.LocalDateExtensions
 
 import javax.inject.Inject
+import scala.util.Random
 
-class AppConfig @Inject() (config: Configuration):
-  val appName: String                     = config.get[String]("appName")
-  val bearerAuthorisationEnabled: Boolean = config.get[Boolean]("feature-toggles.new-auth-check-enabled")
-  val randomSeed: Option[Int]             = config.get[Option[Int]]("random.seed")
+package object generator:
+  case class DefaultBalanceDetailGenerator @Inject() (random: Random)
+      extends BalanceDetailGenerator(using LocalDateExtensions, random)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/models/package.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/models/package.scala
@@ -43,25 +43,21 @@ object PayableDueDate extends StringBasedJsonOps[PayableDueDate]:
   def valueOf(payableDueDate: PayableDueDate): String  = payableDueDate
 
 object TotalBalance:
-  given Writes[TotalBalance] = bigDecimalBasedWrites(apply)
-
   def apply(value: BigDecimal): TotalBalance = value
+  given Writes[TotalBalance]                 = bigDecimalBasedWrites(apply)
 
 object PayableAmount:
-  given Writes[PayableAmount] = bigDecimalBasedWrites(apply)
-
   def apply(value: BigDecimal): PayableAmount = value
+  given Writes[PayableAmount]                 = bigDecimalBasedWrites(apply)
 
   extension (amount: PayableAmount) def ++(other: PendingDueAmount): PendingDueAmount = amount + other
 
 object PendingDueAmount:
-  given Writes[PendingDueAmount] = bigDecimalBasedWrites(apply)
-
   def apply(value: BigDecimal): PendingDueAmount = value
+  given Writes[PendingDueAmount]                 = bigDecimalBasedWrites(apply)
 
   extension (amount: PendingDueAmount) def ++(other: OverdueAmount): BigDecimal = amount + other
 
 object OverdueAmount:
-  given Writes[OverdueAmount] = bigDecimalBasedWrites(apply)
-
   def apply(value: BigDecimal): OverdueAmount = value
+  given Writes[OverdueAmount]                 = bigDecimalBasedWrites(apply)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/models/package.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/models/package.scala
@@ -43,21 +43,25 @@ object PayableDueDate extends StringBasedJsonOps[PayableDueDate]:
   def valueOf(payableDueDate: PayableDueDate): String  = payableDueDate
 
 object TotalBalance:
+  given Writes[TotalBalance] = bigDecimalBasedWrites(apply)
+
   def apply(value: BigDecimal): TotalBalance = value
-  given Writes[TotalBalance]                 = bigDecimalBasedWrites(apply)
 
 object PayableAmount:
+  given Writes[PayableAmount] = bigDecimalBasedWrites(apply)
+
   def apply(value: BigDecimal): PayableAmount = value
-  given Writes[PayableAmount]                 = bigDecimalBasedWrites(apply)
 
   extension (amount: PayableAmount) def ++(other: PendingDueAmount): PendingDueAmount = amount + other
 
 object PendingDueAmount:
+  given Writes[PendingDueAmount] = bigDecimalBasedWrites(apply)
+
   def apply(value: BigDecimal): PendingDueAmount = value
-  given Writes[PendingDueAmount]                 = bigDecimalBasedWrites(apply)
 
   extension (amount: PendingDueAmount) def ++(other: OverdueAmount): BigDecimal = amount + other
 
 object OverdueAmount:
+  given Writes[OverdueAmount] = bigDecimalBasedWrites(apply)
+
   def apply(value: BigDecimal): OverdueAmount = value
-  given Writes[OverdueAmount]                 = bigDecimalBasedWrites(apply)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/service/package.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/service/package.scala
@@ -14,17 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.saliabilitiessandpitstubs.service
+package uk.gov.hmrc.saliabilitiessandpitstubs
 
 import uk.gov.hmrc.saliabilitiessandpitstubs.generator.BalanceDetailGenerator
-import uk.gov.hmrc.saliabilitiessandpitstubs.models.{BalanceDetail, *}
 
-trait BalanceDetailService(using generator: BalanceDetailGenerator):
-  val balanceDetailsByNino: String => Option[BalanceDetail | Seq[BalanceDetail]] = details.get
+import javax.inject.Inject
 
-  private val details: Map[String, BalanceDetail | Seq[BalanceDetail]] = Map(
-    "AA000000A" -> generator.generate,
-    "AA000000B" -> generator.generate,
-    "AA000000C" -> Seq.fill(2)(generator.generate),
-    "AA000000D" -> Seq.fill(4)(generator.generate)
-  )
+package object service:
+  case class DefaultBalanceDetailService @Inject() (generator: BalanceDetailGenerator)
+      extends BalanceDetailService(using generator)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -62,6 +62,9 @@ feature-toggles {
   new-auth-check-enabled = true
 }
 
+random {
+  seed = 42
+}
 
 microservice {
   services {

--- a/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
@@ -22,13 +22,21 @@ import play.api.http.Status
 import play.api.mvc.ControllerComponents
 import play.api.test.Helpers.*
 import play.api.test.{FakeRequest, Helpers}
+import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.AuthorizationActionFilter.OpenAuthAction
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.DefaultOpenAuthAction
+import uk.gov.hmrc.saliabilitiessandpitstubs.generator.DefaultBalanceDetailGenerator
+import uk.gov.hmrc.saliabilitiessandpitstubs.service.{BalanceDetailService, DefaultBalanceDetailService}
+
+import scala.util.Random
 
 class BalanceControllerSpec extends AnyWordSpec with Matchers {
 
   private val fakeRequest                      = FakeRequest("GET", "/AA000000A")
+  private val random: Random                   = new Random()
   private val components: ControllerComponents = Helpers.stubControllerComponents()
-  private val controller                       = new BalanceController(components, new DefaultOpenAuthAction(components.executionContext))
+  private val auth: OpenAuthAction             = new DefaultOpenAuthAction(components.executionContext)
+  private val service: BalanceDetailService    = DefaultBalanceDetailService(DefaultBalanceDetailGenerator(random))
+  private val controller                       = new BalanceController(components, auth, service)
 
   "GET /balance/AA000000A" should {
     "return 200" in {


### PR DESCRIPTION
Update the structure of the stub to support DI using default classes.
Use a seeded random object to provide repeatable results when using the BalanceDetailGenerator.
Allow the seed to be configured through the config file.