### PR TITLE
[DI-296]: Refactor `saveBalance` endpoint to simplify error handling and response generation

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
@@ -19,15 +19,15 @@ package uk.gov.hmrc.saliabilitiessandpitstubs.controllers
 import play.api.Logging
 import play.api.mvc.*
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendBaseController
-import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.{AuthorizationActionFilter, BalanceActions}
+import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.{AuthorizationActionFilter, BalanceActions, SaveNewLiability}
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
 
 import javax.inject.Inject
 
 class BalanceController @Inject() (
-  val controllerComponents: ControllerComponents,
-  auth: AuthorizationActionFilter,
-  service: BalanceDetailService
-) extends BalanceActions(using auth, service),
+  val controllerComponents: ControllerComponents
+)(implicit val auth: AuthorizationActionFilter, service: BalanceDetailService)
+    extends BalanceActions,
+      SaveNewLiability,
       BackendBaseController,
       Logging

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveNewLiability.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveNewLiability.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action
+
+import play.api.libs.json.Json.obj
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.Results.{BadRequest, Created}
+import play.api.mvc.{Action, BaseController, Request, Result}
+import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.SaveNewLiability.{CreatedNewLiabilityResult, InvalidBalanceDetailErrorResult}
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
+import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
+
+import scala.concurrent.Future
+import scala.concurrent.Future.*
+
+private[controllers] trait SaveNewLiability(using auth: AuthorizationActionFilter, service: BalanceDetailService):
+  self: BaseController =>
+
+  def saveNewBalanceByNino(nino: String): Action[JsValue] = (Action andThen auth).async(parse.json)(
+    (_: Request[JsValue]).body
+      .validate[BalanceDetail]
+      .fold(
+        errors => handleValidationError,
+        balanceDetail => {
+          service.addOrUpdateBalanceDetail(nino, balanceDetail)
+          handleSuccess
+        }
+      )
+  )
+
+  private def handleValidationError: Future[Result] = successful(InvalidBalanceDetailErrorResult)
+
+  private def handleSuccess: Future[Result] = successful(CreatedNewLiabilityResult)
+
+private[this] object SaveNewLiability:
+  val InvalidBalanceDetailErrorResult: Result = BadRequest(obj("error" -> "Invalid balance detail format"))
+  val CreatedNewLiabilityResult: Result       = Created(obj("status" -> "Balance updated successfully"))

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/json/package.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/json/package.scala
@@ -22,8 +22,10 @@ import java.time.LocalDate
 
 package object json:
   def bigDecimalBasedWrites[T](f: T => BigDecimal): Writes[T] = Writes.BigDecimalWrites.contramap(f)
+  def bigDecimalBasedReads: Reads[BigDecimal]                 = (json: JsValue) => json.validate[BigDecimal]
 
   trait StringBasedJsonOps[T]:
     def apply(value: String | LocalDate): T
     def valueOf(t: T): String
-    given Writes[T] = Writes[T](t => Json.toJson(valueOf(t)))
+    given Writes[T] = Writes.StringWrites.contramap(valueOf)
+    given Reads[T]  = Reads.StringReads.map(apply)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/models/BalanceDetail.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/models/BalanceDetail.scala
@@ -18,7 +18,8 @@ package uk.gov.hmrc.saliabilitiessandpitstubs.models
 
 import play.api.http.{ContentTypes, Writeable}
 import play.api.libs.json.*
-import play.api.libs.json.Json.{toJson, writes}
+import play.api.libs.json.Json.toJson
+import uk.gov.hmrc.saliabilitiessandpitstubs.json.{StringBasedJsonOps, bigDecimalBasedReads, bigDecimalBasedWrites}
 import uk.gov.hmrc.saliabilitiessandpitstubs.models.*
 
 import scala.annotation.targetName
@@ -34,7 +35,7 @@ case class BalanceDetail(
 )
 
 object BalanceDetail:
-  given OWrites[BalanceDetail] = writes[BalanceDetail]
+  given Format[BalanceDetail] = Json.format[BalanceDetail]
 
   @targetName("UnionOfWriteableIterableBalanceDetail")
   given Writeable[Iterable[BalanceDetail] | BalanceDetail] =

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/models/package.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/models/package.scala
@@ -17,7 +17,7 @@
 package uk.gov.hmrc.saliabilitiessandpitstubs.models
 
 import play.api.libs.json.{Reads, Writes}
-import uk.gov.hmrc.saliabilitiessandpitstubs.json.{StringBasedJsonOps, bigDecimalBasedWrites}
+import uk.gov.hmrc.saliabilitiessandpitstubs.json.{StringBasedJsonOps, bigDecimalBasedReads, bigDecimalBasedWrites}
 
 import java.time.LocalDate
 
@@ -45,19 +45,21 @@ object PayableDueDate extends StringBasedJsonOps[PayableDueDate]:
 object TotalBalance:
   def apply(value: BigDecimal): TotalBalance = value
   given Writes[TotalBalance]                 = bigDecimalBasedWrites(apply)
+  given Reads[TotalBalance]                  = bigDecimalBasedReads
 
 object PayableAmount:
-  def apply(value: BigDecimal): PayableAmount = value
-  given Writes[PayableAmount]                 = bigDecimalBasedWrites(apply)
-
+  def apply(value: BigDecimal): PayableAmount                                         = value
+  given Writes[PayableAmount]                                                         = bigDecimalBasedWrites(apply)
+  given Reads[PayableAmount]                                                          = bigDecimalBasedReads
   extension (amount: PayableAmount) def ++(other: PendingDueAmount): PendingDueAmount = amount + other
 
 object PendingDueAmount:
-  def apply(value: BigDecimal): PendingDueAmount = value
-  given Writes[PendingDueAmount]                 = bigDecimalBasedWrites(apply)
-
+  def apply(value: BigDecimal): PendingDueAmount                                = value
+  given Writes[PendingDueAmount]                                                = bigDecimalBasedWrites(apply)
+  given Reads[PendingDueAmount]                                                 = bigDecimalBasedReads
   extension (amount: PendingDueAmount) def ++(other: OverdueAmount): BigDecimal = amount + other
 
 object OverdueAmount:
   def apply(value: BigDecimal): OverdueAmount = value
   given Writes[OverdueAmount]                 = bigDecimalBasedWrites(apply)
+  given Reads[OverdueAmount]                  = bigDecimalBasedReads

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/service/BalanceDetailService.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/service/BalanceDetailService.scala
@@ -20,11 +20,18 @@ import uk.gov.hmrc.saliabilitiessandpitstubs.generator.BalanceDetailGenerator
 import uk.gov.hmrc.saliabilitiessandpitstubs.models.{BalanceDetail, *}
 
 trait BalanceDetailService(using generator: BalanceDetailGenerator):
-  val balanceDetailsByNino: String => Option[BalanceDetail | Seq[BalanceDetail]] = details.get
 
-  private val details: Map[String, BalanceDetail | Seq[BalanceDetail]] = Map(
+  private var details: Map[String, BalanceDetail | Seq[BalanceDetail]] = Map(
     "AA000000A" -> generator.generate,
     "AA000000B" -> generator.generate,
     "AA000000C" -> Seq.fill(2)(generator.generate),
     "AA000000D" -> Seq.fill(4)(generator.generate)
   )
+
+  val balanceDetailsByNino: String => Option[BalanceDetail | Seq[BalanceDetail]] = details.get(_: String)
+
+  val addOrUpdateBalanceDetail: (String, BalanceDetail) => Unit = (nino: String, balanceDetail: BalanceDetail) =>
+    details = details.get(nino) match
+      case Some(existingDetail: BalanceDetail)       => details + (nino -> Seq(existingDetail, balanceDetail))
+      case Some(existingDetails: Seq[BalanceDetail]) => details + (nino -> (existingDetails :+ balanceDetail))
+      case None                                      => details + (nino -> balanceDetail)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,3 +1,4 @@
 # microservice specific routes
 
 GET        /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.getBalanceByNino(nino: String)
+POST       /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.saveNewBalanceByNino(nino: String)

--- a/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
@@ -36,7 +36,7 @@ class BalanceControllerSpec extends AnyWordSpec with Matchers {
   private val components: ControllerComponents = Helpers.stubControllerComponents()
   private val auth: OpenAuthAction             = new DefaultOpenAuthAction(components.executionContext)
   private val service: BalanceDetailService    = DefaultBalanceDetailService(DefaultBalanceDetailGenerator(random))
-  private val controller                       = new BalanceController(components, auth, service)
+  private val controller                       = new BalanceController(components)(auth, service)
 
   "GET /balance/AA000000A" should {
     "return 200" in {


### PR DESCRIPTION
Refactored the balance endpoint to improve code readability and simplify error handling. The changes include:

- Added a new endpoint saveBalance to handle saving balance details for a given NINO.
- The new endpoint processes JSON input to update or add balance details.
- It now handles validation gracefully and returns appropriate HTTP responses.
- Updated to use helper methods for consistency and clarity.

This update enhances maintainability and ensures a more consistent response structure.