### PR TITLE
[DI-296]: Create `generateLiabilities` endpoint to simplify data creation process

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
@@ -21,13 +21,21 @@ import play.api.mvc.*
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendBaseController
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.{AuthorizationActionFilter, BalanceActions, SaveNewLiability}
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
+import uk.gov.hmrc.saliabilitiessandpitstubs.utils.DelaySimulator
 
 import javax.inject.Inject
+import scala.concurrent.ExecutionContext
+import scala.util.Random
 
 class BalanceController @Inject() (
   val controllerComponents: ControllerComponents
-)(implicit val auth: AuthorizationActionFilter, service: BalanceDetailService)
-    extends BalanceActions,
+)(implicit
+  val auth: AuthorizationActionFilter,
+  service: BalanceDetailService,
+  random: Random,
+  executionContext: ExecutionContext
+) extends BalanceActions,
       SaveNewLiability,
       BackendBaseController,
+      DelaySimulator,
       Logging

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/BalanceActions.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/BalanceActions.scala
@@ -16,27 +16,23 @@
 
 package uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action
 
-import play.api.Logging
 import play.api.libs.json.Json
-import play.api.mvc.{Action, AnyContent, BaseController, Request}
+import play.api.mvc.Results.NotFound
+import play.api.mvc.{Action, AnyContent, BaseController, Request, Result}
+import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.BalanceActions.BalanceLiabilityNotFoundResult
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
+import uk.gov.hmrc.saliabilitiessandpitstubs.utils.DelaySimulator
 
-import scala.concurrent.Future
-import scala.concurrent.Future.successful
-
-private[controllers] trait BalanceActions(using auth: AuthorizationActionFilter, service: BalanceDetailService) {
-  self: BaseController & Logging =>
+private[controllers] trait BalanceActions(using auth: AuthorizationActionFilter, service: BalanceDetailService):
+  self: BaseController & DelaySimulator =>
 
   def getBalanceByNino(nino: String): Action[AnyContent] = (Action andThen auth).async { implicit request: Request[_] =>
-    logger.debug(s"Looking up balance for NINO: $nino")
-    service.balanceDetailsByNino(nino) match {
-      case Some(balance) =>
-        logger.debug(s"Found balance for NINO $nino: $balance")
-        successful(Ok(balance))
-      case None          =>
-        logger.debug(s"No balance found for NINO $nino")
-        val notFoundResult = NotFound(Json.obj("error" -> s"No balance found for NINO $nino"))
-        successful(notFoundResult)
+    simulateNetworkConditions {
+      service.balanceDetailsByNino(nino) match
+        case Some(balance) => Ok(balance)
+        case None          => BalanceLiabilityNotFoundResult
     }
   }
-}
+
+object BalanceActions:
+  val BalanceLiabilityNotFoundResult: Result = NotFound(Json.obj("error" -> s"No balance found"))

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveNewLiability.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveNewLiability.scala
@@ -24,11 +24,14 @@ import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.SaveNewLiability
 import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.Future.*
-import scala.concurrent.ExecutionContext.Implicits.global
 
-private[controllers] trait SaveNewLiability(using auth: AuthorizationActionFilter, service: BalanceDetailService):
+private[controllers] trait SaveNewLiability(using
+  auth: AuthorizationActionFilter,
+  service: BalanceDetailService,
+  executionContext: ExecutionContext
+):
   self: BaseController =>
 
   def saveNewBalanceByNino(nino: String): Action[JsValue] = (Action andThen auth).async(parse.json)(
@@ -47,8 +50,8 @@ private[controllers] trait SaveNewLiability(using auth: AuthorizationActionFilte
     implicit request: Request[AnyContent] =>
       Future(service addOrUpdateGeneratedBalanceDetail nino) map (_ => CreatedNewLiabilityResult)
   }
-  
-  private def handleValidationError: Future[Result]                = successful(InvalidBalanceDetailErrorResult)
+
+  private def handleValidationError: Future[Result] = successful(InvalidBalanceDetailErrorResult)
 
   private def handleSuccess: Future[Result] = successful(CreatedNewLiabilityResult)
 

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveNewLiability.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveNewLiability.scala
@@ -19,13 +19,14 @@ package uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action
 import play.api.libs.json.Json.obj
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.Results.{BadRequest, Created}
-import play.api.mvc.{Action, BaseController, Request, Result}
+import play.api.mvc.{Action, AnyContent, BaseController, Request, Result}
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.SaveNewLiability.{CreatedNewLiabilityResult, InvalidBalanceDetailErrorResult}
 import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
 
 import scala.concurrent.Future
 import scala.concurrent.Future.*
+import scala.concurrent.ExecutionContext.Implicits.global
 
 private[controllers] trait SaveNewLiability(using auth: AuthorizationActionFilter, service: BalanceDetailService):
   self: BaseController =>
@@ -42,7 +43,12 @@ private[controllers] trait SaveNewLiability(using auth: AuthorizationActionFilte
       )
   )
 
-  private def handleValidationError: Future[Result] = successful(InvalidBalanceDetailErrorResult)
+  def saveGeneratedBalanceByNino(nino: String): Action[AnyContent] = Action andThen auth async {
+    implicit request: Request[AnyContent] =>
+      Future(service addOrUpdateGeneratedBalanceDetail nino) map (_ => CreatedNewLiabilityResult)
+  }
+  
+  private def handleValidationError: Future[Result]                = successful(InvalidBalanceDetailErrorResult)
 
   private def handleSuccess: Future[Result] = successful(CreatedNewLiabilityResult)
 

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/service/BalanceDetailService.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/service/BalanceDetailService.scala
@@ -35,3 +35,5 @@ trait BalanceDetailService(using generator: BalanceDetailGenerator):
       case Some(existingDetail: BalanceDetail)       => details + (nino -> Seq(existingDetail, balanceDetail))
       case Some(existingDetails: Seq[BalanceDetail]) => details + (nino -> (existingDetails :+ balanceDetail))
       case None                                      => details + (nino -> balanceDetail)
+
+  val addOrUpdateGeneratedBalanceDetail: String => Unit = addOrUpdateBalanceDetail(_: String, generator.generate)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/DelaySimulator.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/DelaySimulator.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitstubs.utils
+
+import org.apache.pekko
+import org.apache.pekko.*
+import org.apache.pekko.actor.*
+import org.apache.pekko.pattern.after
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Future.*
+import scala.concurrent.duration.*
+import scala.concurrent.{ExecutionContext, Future, TimeoutException}
+import scala.util.Random
+
+trait DelaySimulator(using random: Random, executionContext: ExecutionContext):
+
+  def simulateRandomDelay[T](result: T, maxDelay: FiniteDuration = 1000.millis): Future[T] =
+    val randomDelay = FiniteDuration(random.between(50, maxDelay.toMillis), TimeUnit.MILLISECONDS)
+    after(randomDelay, using = ActorSystem().scheduler)(successful(result))
+
+  def simulateFailureWithDelay[T](result: T, delay: FiniteDuration = 1.seconds, failureRate: Double = 0.5): Future[T] =
+    if random.nextDouble < failureRate then
+      after(delay, using = ActorSystem().scheduler)(failed(new RuntimeException("Simulated failure")))
+    else after(delay, using = ActorSystem().scheduler)(successful(result))
+
+  def simulateThrottling[T](result: T, throttleDuration: FiniteDuration = 3.seconds): Future[T] =
+    after(throttleDuration, using = ActorSystem().scheduler)(successful(result))
+
+  def simulateTimeout[T](timeoutDuration: FiniteDuration = 10.seconds): Future[T] =
+    after(timeoutDuration, using = ActorSystem().scheduler)(failed(new TimeoutException("Simulated timeout")))
+
+  def simulateNetworkConditions[T](result: T): Future[T] = random.nextDouble match
+    case r if r < 0.15 => simulateFailureWithDelay(result)
+    case r if r < 0.30 => simulateRandomDelay(result)
+    case r if r < 0.45 => simulateThrottling(result)
+    case r if r < 0.60 => simulateTimeout()
+    case _             => successful(result)

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,4 +1,5 @@
 # microservice specific routes
 
 GET        /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.getBalanceByNino(nino: String)
-POST       /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.saveNewBalanceByNino(nino: String)
+PUT        /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.saveNewBalanceByNino(nino: String)
+POST       /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.saveGeneratedBalanceByNino(nino: String)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,20 +1,19 @@
-import play.core.PlayVersion
-import play.sbt.PlayImport._
-import sbt.Keys.libraryDependencies
-import sbt._
+import play.sbt.PlayImport.*
+import sbt.*
 
 object AppDependencies {
 
   private val bootstrapVersion = "9.1.0"
-  
+  private val PekkoVersion = "1.0.2"
 
   val compile = Seq(
-    "uk.gov.hmrc"             %% "bootstrap-backend-play-30"  % bootstrapVersion
+    "uk.gov.hmrc"             %% "bootstrap-backend-play-30"  % bootstrapVersion,
+    "org.apache.pekko"        %% "pekko-stream"               % PekkoVersion,
   )
 
   val test = Seq(
     "uk.gov.hmrc"             %% "bootstrap-test-play-30"     % bootstrapVersion            % Test,
-    
+    "org.apache.pekko"        %% "pekko-stream-testkit"       % PekkoVersion                % Test
   )
 
   val it = Seq.empty

--- a/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
@@ -27,16 +27,18 @@ import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.DefaultOpenAuthA
 import uk.gov.hmrc.saliabilitiessandpitstubs.generator.DefaultBalanceDetailGenerator
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.{BalanceDetailService, DefaultBalanceDetailService}
 
+import scala.concurrent.ExecutionContext
 import scala.util.Random
 
 class BalanceControllerSpec extends AnyWordSpec with Matchers {
 
   private val fakeRequest                      = FakeRequest("GET", "/AA000000A")
-  private val random: Random                   = new Random()
   private val components: ControllerComponents = Helpers.stubControllerComponents()
-  private val auth: OpenAuthAction             = new DefaultOpenAuthAction(components.executionContext)
-  private val service: BalanceDetailService    = DefaultBalanceDetailService(DefaultBalanceDetailGenerator(random))
-  private val controller                       = new BalanceController(components)(auth, service)
+  given random: Random                         = new Random()
+  given executionContext: ExecutionContext     = components.executionContext
+  given auth: OpenAuthAction                   = new DefaultOpenAuthAction(executionContext)
+  given service: BalanceDetailService          = DefaultBalanceDetailService(DefaultBalanceDetailGenerator(random))
+  private val controller                       = new BalanceController(components)
 
   "GET /balance/AA000000A" should {
     "return 200" in {


### PR DESCRIPTION
Refactored the balance stub endpoint to include data creation endpoint. The changes include:

- Added a new endpoint to handle saving balance details for a given NINO.
- The new endpoint generate data and add it to the balance details.
-  It now handles validation gracefully and returns appropriate HTTP responses.
- Updated to use helper methods for consistency and clarity.

