### PR TITLE
[DI-296]: Introduce a new creation strategy that allows users to select between different generation strategies using a header parameter.

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/AppConfig.scala
@@ -17,10 +17,15 @@
 package uk.gov.hmrc.saliabilitiessandpitstubs.config
 
 import play.api.Configuration
+import uk.gov.hmrc.saliabilitiessandpitstubs.generator.GenerationStrategy
 
 import javax.inject.Inject
 
 class AppConfig @Inject() (config: Configuration):
-  val appName: String                     = config.get[String]("appName")
-  val bearerAuthorisationEnabled: Boolean = config.get[Boolean]("feature-toggles.new-auth-check-enabled")
-  val randomSeed: Option[Int]             = config.get[Option[Int]]("random.seed")
+  val appName: String                           = config.get[String]("appName")
+  val bearerAuthorisationEnabled: Boolean       = config.get[Boolean]("feature-toggles.new-auth-check-enabled")
+  val randomSeed: Option[Int]                   = config.get[Option[Int]]("generator.random.seed")
+  val defaultGenerator: GenerationStrategy      = config.get[GenerationStrategy]("generator.default")
+  val defaultGenerationHeader: String           = config.get[String]("generator.request.header")
+  val balanceDetailValidatorFields: Seq[String] = config.get[Seq[String]]("validation.balance.fields")
+  val balanceDetailValidationEnable: Boolean    = config.get[Boolean]("validation.balance.enable")

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Module.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Module.scala
@@ -16,10 +16,11 @@
 
 package uk.gov.hmrc.saliabilitiessandpitstubs.config
 
+import com.github.javafaker.Faker
 import com.google.inject.AbstractModule
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.AuthorizationActionFilter
-import uk.gov.hmrc.saliabilitiessandpitstubs.generator.{BalanceDetailGenerator, DefaultBalanceDetailGenerator}
+import uk.gov.hmrc.saliabilitiessandpitstubs.generator.*
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.{BalanceDetailService, DefaultBalanceDetailService}
 
 import scala.util.Random
@@ -27,11 +28,14 @@ import scala.util.Random
 class Module extends AbstractModule {
 
   override def configure(): Unit = {
+    bind(classOf[Faker]).asEagerSingleton()
     bind(classOf[AppConfig]).asEagerSingleton()
     bind(classOf[BalanceController]).asEagerSingleton()
-    bind(classOf[BalanceDetailGenerator]).to(classOf[DefaultBalanceDetailGenerator]).asEagerSingleton()
+    bind(classOf[Random]).toProvider(classOf[RandomProvider]).asEagerSingleton()
+    bind(classOf[BalanceDetailFaker]).to(classOf[DefaultBalanceDetailFaker]).asEagerSingleton()
     bind(classOf[BalanceDetailService]).to(classOf[DefaultBalanceDetailService]).asEagerSingleton()
     bind(classOf[AuthorizationActionFilter]).toProvider(classOf[AuthActionProvider]).asEagerSingleton()
-    bind(classOf[Random]).toProvider(classOf[RandomProvider]).asEagerSingleton()
+    bind(classOf[BalanceDetailRandomize]).to(classOf[DefaultBalanceDetailGenerator]).asEagerSingleton()
+    bind(classOf[BalanceDetailGeneratorResolver]).to(classOf[DefaultBalanceDetailGeneratorResolver]).asEagerSingleton()
   }
 }

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Module.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Module.scala
@@ -17,10 +17,12 @@
 package uk.gov.hmrc.saliabilitiessandpitstubs.config
 
 import com.github.javafaker.Faker
-import com.google.inject.AbstractModule
+import com.google.inject.{AbstractModule, TypeLiteral}
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.AuthorizationActionFilter
 import uk.gov.hmrc.saliabilitiessandpitstubs.generator.*
+import uk.gov.hmrc.saliabilitiessandpitstubs.json.JsValidator
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.{BalanceDetailService, DefaultBalanceDetailService}
 
 import scala.util.Random
@@ -36,6 +38,12 @@ class Module extends AbstractModule {
     bind(classOf[BalanceDetailService]).to(classOf[DefaultBalanceDetailService]).asEagerSingleton()
     bind(classOf[AuthorizationActionFilter]).toProvider(classOf[AuthActionProvider]).asEagerSingleton()
     bind(classOf[BalanceDetailRandomize]).to(classOf[DefaultBalanceDetailGenerator]).asEagerSingleton()
+    bind(classOf[BalanceDetailInitialGeneratorResolver])
+      .to(classOf[DefaultBalanceDetailInitialGeneratorResolver])
+      .asEagerSingleton()
     bind(classOf[BalanceDetailGeneratorResolver]).to(classOf[DefaultBalanceDetailGeneratorResolver]).asEagerSingleton()
+    bind(new TypeLiteral[JsValidator[BalanceDetail]]() {})
+      .toProvider(classOf[BalanceDetailValidatorRequestProvider])
+      .asEagerSingleton()
   }
 }

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Providers.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Providers.scala
@@ -18,6 +18,9 @@
 package uk.gov.hmrc.saliabilitiessandpitstubs.config
 
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.{AuthorizationActionFilter, DefaultOpenAuthAction, DefaultTokenBasedAction}
+import uk.gov.hmrc.saliabilitiessandpitstubs.json.JsValidator
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
+import uk.gov.hmrc.saliabilitiessandpitstubs.validator.{BalanceDetailValidator, ModelBasedBalanceDetailValidator}
 
 import javax.inject.{Inject, Provider}
 import scala.concurrent.ExecutionContext
@@ -32,3 +35,14 @@ class AuthActionProvider @Inject() (config: AppConfig, executionContext: Executi
 
 class RandomProvider @Inject() (config: AppConfig) extends Provider[Random]:
   val get: Random = (config.randomSeed fold Random())(Random(_))
+
+class BalanceDetailValidatorRequestProvider @Inject() (config: AppConfig) extends Provider[JsValidator[BalanceDetail]]:
+  val get: JsValidator[BalanceDetail] =
+    if config.balanceDetailValidationEnable then
+      classOf[BalanceDetailValidator]
+        .getConstructor(classOf[Set[String]])
+        .newInstance(Set("pendingDueAmount", "overdueAmount", "payableAmount"))
+    else
+      classOf[ModelBasedBalanceDetailValidator]
+        .getConstructor()
+        .newInstance()

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
@@ -21,6 +21,7 @@ import play.api.mvc.*
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendBaseController
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.*
 import uk.gov.hmrc.saliabilitiessandpitstubs.http.Streamliner
+import uk.gov.hmrc.saliabilitiessandpitstubs.json.JsValidator
 import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
 import uk.gov.hmrc.saliabilitiessandpitstubs.utils.DelaySimulator
@@ -35,7 +36,8 @@ class BalanceController @Inject() (
   val auth: AuthorizationActionFilter,
   service: BalanceDetailService,
   random: Random,
-  executionContext: ExecutionContext
+  executionContext: ExecutionContext,
+  jsValidator: JsValidator[BalanceDetail]
 ) extends BalanceActions,
       SaveNewLiability,
       SaveGeneratedLiability,

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
@@ -20,6 +20,8 @@ import play.api.Logging
 import play.api.mvc.*
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendBaseController
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.{AuthorizationActionFilter, BalanceActions, SaveNewLiability}
+import uk.gov.hmrc.saliabilitiessandpitstubs.http.Streamliner
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
 import uk.gov.hmrc.saliabilitiessandpitstubs.utils.DelaySimulator
 
@@ -36,6 +38,7 @@ class BalanceController @Inject() (
   executionContext: ExecutionContext
 ) extends BalanceActions,
       SaveNewLiability,
+      Streamliner[BalanceDetail],
       BackendBaseController,
       DelaySimulator,
       Logging

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.saliabilitiessandpitstubs.controllers
 import play.api.Logging
 import play.api.mvc.*
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendBaseController
-import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.{AuthorizationActionFilter, BalanceActions, SaveNewLiability}
+import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.*
 import uk.gov.hmrc.saliabilitiessandpitstubs.http.Streamliner
 import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
@@ -38,6 +38,7 @@ class BalanceController @Inject() (
   executionContext: ExecutionContext
 ) extends BalanceActions,
       SaveNewLiability,
+      SaveGeneratedLiability,
       Streamliner[BalanceDetail],
       BackendBaseController,
       DelaySimulator,

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveGeneratedLiability.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveGeneratedLiability.scala
@@ -16,16 +16,13 @@
 
 package uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action
 
-import play.api.libs.json.JsValue
 import play.api.libs.json.Json.obj
-import play.api.mvc.{Action, AnyContent, BaseController, Request, Result}
-import play.api.mvc.Results.{BadRequest, Created}
+import play.api.mvc.Results.Created
+import play.api.mvc.*
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.SaveGeneratedLiability.CreatedNewLiabilityResult
-import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.Future.successful
 
 private[controllers] trait SaveGeneratedLiability(using
   auth: AuthorizationActionFilter,

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveGeneratedLiability.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveGeneratedLiability.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action
+
+import play.api.libs.json.JsValue
+import play.api.libs.json.Json.obj
+import play.api.mvc.{Action, AnyContent, BaseController, Request, Result}
+import play.api.mvc.Results.{BadRequest, Created}
+import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.SaveGeneratedLiability.CreatedNewLiabilityResult
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
+import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
+
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future.successful
+
+private[controllers] trait SaveGeneratedLiability(using
+  auth: AuthorizationActionFilter,
+  service: BalanceDetailService,
+  executionContext: ExecutionContext
+):
+  self: BaseController =>
+
+  val saveGeneratedBalanceByNino: String => Action[AnyContent] = (nino: String) =>
+    Action andThen auth async { implicit request: Request[AnyContent] =>
+      Future(service addOrUpdateGeneratedBalanceDetail nino) map (_ => CreatedNewLiabilityResult)
+    }
+
+private[this] object SaveGeneratedLiability:
+  val CreatedNewLiabilityResult: Result = Created(obj("status" -> "Balance updated successfully"))

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveNewLiability.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveNewLiability.scala
@@ -24,8 +24,8 @@ import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.SaveNewLiability
 import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
 
-import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.Future.*
+import scala.concurrent.{ExecutionContext, Future}
 
 private[controllers] trait SaveNewLiability(using
   auth: AuthorizationActionFilter,

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveNewLiability.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveNewLiability.scala
@@ -19,37 +19,32 @@ package uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action
 import play.api.libs.json.Json.obj
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.Results.{BadRequest, Created}
-import play.api.mvc.{Action, AnyContent, BaseController, Request, Result}
+import play.api.mvc.{Action, BaseController, Request, Result}
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.SaveNewLiability.{CreatedNewLiabilityResult, InvalidBalanceDetailErrorResult}
 import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
 
+import scala.concurrent.Future
 import scala.concurrent.Future.*
-import scala.concurrent.{ExecutionContext, Future}
 
 private[controllers] trait SaveNewLiability(using
   auth: AuthorizationActionFilter,
-  service: BalanceDetailService,
-  executionContext: ExecutionContext
+  service: BalanceDetailService
 ):
   self: BaseController =>
 
-  def saveNewBalanceByNino(nino: String): Action[JsValue] = (Action andThen auth).async(parse.json)(
-    (_: Request[JsValue]).body
-      .validate[BalanceDetail]
-      .fold(
-        errors => handleValidationError,
-        balanceDetail => {
-          service.addOrUpdateBalanceDetail(nino, balanceDetail)
-          handleSuccess
-        }
-      )
-  )
-
-  def saveGeneratedBalanceByNino(nino: String): Action[AnyContent] = Action andThen auth async {
-    implicit request: Request[AnyContent] =>
-      Future(service addOrUpdateGeneratedBalanceDetail nino) map (_ => CreatedNewLiabilityResult)
-  }
+  val saveNewBalanceByNino: String => Action[JsValue] = nino =>
+    (Action andThen auth async parse.json)(
+      (_: Request[JsValue]).body
+        .validate[BalanceDetail]
+        .fold(
+          errors => handleValidationError,
+          balanceDetail => {
+            service.addOrUpdateBalanceDetail(nino, balanceDetail)
+            handleSuccess
+          }
+        )
+    )
 
   private def handleValidationError: Future[Result] = successful(InvalidBalanceDetailErrorResult)
 

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveNewLiability.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/SaveNewLiability.scala
@@ -21,6 +21,7 @@ import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.Results.{BadRequest, Created}
 import play.api.mvc.{Action, BaseController, Request, Result}
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.SaveNewLiability.{CreatedNewLiabilityResult, InvalidBalanceDetailErrorResult}
+import uk.gov.hmrc.saliabilitiessandpitstubs.json.JsValidator
 import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
 
@@ -29,14 +30,15 @@ import scala.concurrent.Future.*
 
 private[controllers] trait SaveNewLiability(using
   auth: AuthorizationActionFilter,
-  service: BalanceDetailService
+  service: BalanceDetailService,
+  jsValidator: JsValidator[BalanceDetail]
 ):
   self: BaseController =>
 
   val saveNewBalanceByNino: String => Action[JsValue] = nino =>
     (Action andThen auth async parse.json)(
       (_: Request[JsValue]).body
-        .validate[BalanceDetail]
+        .validate(jsValidator.validate)
         .fold(
           errors => handleValidationError,
           balanceDetail => {

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailFaker.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailFaker.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitstubs.generator
+
+import com.github.javafaker.Faker
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.*
+import uk.gov.hmrc.saliabilitiessandpitstubs.time.FakerExtensions
+
+import java.time.{Clock, LocalDate, ZoneId}
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeUnit.DAYS
+
+trait BalanceDetailFaker(using faker: Faker) extends BalanceDetailGenerator:
+  self: FakerExtensions =>
+
+  def generate: BalanceDetail =
+    val payableDueDate   = PayableDueDate(faker dateInFuture (30, DAYS))
+    val pendingDueDate   = PendingDueDate(faker dateInFuture (60, DAYS))
+    val overdueAmount    = OverdueAmount(faker.number() numberBetween (0, 10000))
+    val payableAmount    = PayableAmount(faker.number() numberBetween (1000, 10000))
+    val pendingDueAmount = PendingDueAmount(faker.number() numberBetween (100, 5000))
+    val totalBalance     = TotalBalance(payableAmount ++ pendingDueAmount ++ overdueAmount)
+
+    BalanceDetail(payableAmount, payableDueDate, pendingDueAmount, pendingDueDate, overdueAmount, totalBalance)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGenerator.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGenerator.scala
@@ -16,27 +16,7 @@
 
 package uk.gov.hmrc.saliabilitiessandpitstubs.generator
 
-import uk.gov.hmrc.saliabilitiessandpitstubs.models.*
-import uk.gov.hmrc.saliabilitiessandpitstubs.time.LocalDateExtensions
-import uk.gov.hmrc.saliabilitiessandpitstubs.time.LocalDateExtensions.nextDayInFuture
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 
-import scala.util.Random
-import scala.util.Random.nextInt
-
-trait BalanceDetailGenerator(using LocalDateExtensions)(random: Random):
-
-  private def randomInRange(range: Range): Int =
-    val start = Math.min(range.start, range.end)
-    val end   = Math.max(range.start, range.end)
-
-    start + random.nextInt((end - start) + 1)
-
-  def generate: BalanceDetail =
-    val pendingDueDate   = PendingDueDate(nextDayInFuture(monthsToAdd = 3))
-    val payableDueDate   = PayableDueDate(nextDayInFuture(monthsToAdd = 6))
-    val overdueAmount    = OverdueAmount(randomInRange(0 to 9999))
-    val payableAmount    = PayableAmount(randomInRange(0 to 9999))
-    val pendingDueAmount = PendingDueAmount(randomInRange(0 to 9999))
-    val totalBalance     = TotalBalance(payableAmount ++ pendingDueAmount ++ overdueAmount)
-
-    BalanceDetail(payableAmount, payableDueDate, pendingDueAmount, pendingDueDate, overdueAmount, totalBalance)
+trait BalanceDetailGenerator:
+  def generate: BalanceDetail

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGeneratorBackendHeaderCarrierProvider.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGeneratorBackendHeaderCarrierProvider.scala
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.saliabilitiessandpitstubs
+package uk.gov.hmrc.saliabilitiessandpitstubs.generator
 
-import uk.gov.hmrc.saliabilitiessandpitstubs.generator.{BalanceDetailGeneratorResolver, BalanceDetailInitialGeneratorResolver, BalanceDetailRandomize}
+import play.api.mvc.{AnyContent, Request}
+import uk.gov.hmrc.saliabilitiessandpitstubs.generator.GenerationStrategy.loadStrategy
 
-import javax.inject.Inject
+trait BalanceDetailGeneratorBackendHeaderCarrierProvider(using header: String):
 
-package object service:
-  case class DefaultBalanceDetailService @Inject() (
-    generator: BalanceDetailInitialGeneratorResolver,
-    res: BalanceDetailGeneratorResolver
-  ) extends BalanceDetailService(using generator, res)
+  extension (request: Request[AnyContent])
+    def generationStrategy: Option[GenerationStrategy] =
+      request.headers get header flatMap loadStrategy

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGeneratorResolver.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailGeneratorResolver.scala
@@ -14,14 +14,20 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.saliabilitiessandpitstubs
+package uk.gov.hmrc.saliabilitiessandpitstubs.generator
 
-import uk.gov.hmrc.saliabilitiessandpitstubs.generator.{BalanceDetailGeneratorResolver, BalanceDetailRandomize}
+import play.api.mvc.{AnyContent, Request}
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 
-import javax.inject.Inject
+trait BalanceDetailGeneratorResolver(using faker: BalanceDetailFaker, randomize: BalanceDetailRandomize):
 
-package object service:
-  case class DefaultBalanceDetailService @Inject() (
-    generator: BalanceDetailRandomize,
-    res: BalanceDetailGeneratorResolver
-  ) extends BalanceDetailService(using generator, res)
+  private val strategies: Map[String, BalanceDetailGenerator] = Map(
+    "fake"      -> faker,
+    "randomize" -> randomize
+  )
+
+  def generate(implicit request: Request[AnyContent]): BalanceDetail =
+    (request.headers get "X-USE-STRATEGY-GENERATION")
+      .flatMap(strategies.get)
+      .getOrElse(randomize)
+      .generate

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailInitialGeneratorResolver.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailInitialGeneratorResolver.scala
@@ -17,19 +17,19 @@
 package uk.gov.hmrc.saliabilitiessandpitstubs.generator
 
 import play.api.mvc.{AnyContent, Request}
-import uk.gov.hmrc.saliabilitiessandpitstubs.generator.GenerationStrategy.{Faker, Randomize, loadStrategy}
+import uk.gov.hmrc.saliabilitiessandpitstubs.config.AppConfig
+import uk.gov.hmrc.saliabilitiessandpitstubs.generator.GenerationStrategy.{Faker, Randomize}
 import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 
-trait BalanceDetailGeneratorResolver(using faker: BalanceDetailFaker, randomize: BalanceDetailRandomize):
-  self: BalanceDetailGeneratorBackendHeaderCarrierProvider =>
+trait BalanceDetailInitialGeneratorResolver(using
+  faker: BalanceDetailFaker,
+  randomize: BalanceDetailRandomize,
+  config: AppConfig
+):
 
   private val strategies: Map[GenerationStrategy, BalanceDetailGenerator] = Map(
     Faker     -> faker,
     Randomize -> randomize
   )
 
-  def generate(implicit request: Request[AnyContent]): BalanceDetail =
-    request.generationStrategy
-      .flatMap(strategies.get)
-      .getOrElse(randomize)
-      .generate
+  val generate: BalanceDetail = strategies.getOrElse(config.defaultGenerator, randomize).generate

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailRandomize.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/BalanceDetailRandomize.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitstubs.generator
+
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.{BalanceDetail, OverdueAmount, PayableAmount, PayableDueDate, PendingDueAmount, PendingDueDate, TotalBalance}
+import uk.gov.hmrc.saliabilitiessandpitstubs.time.LocalDateExtensions
+import uk.gov.hmrc.saliabilitiessandpitstubs.time.LocalDateExtensions.nextDayInFuture
+
+import scala.util.Random
+
+trait BalanceDetailRandomize(using LocalDateExtensions)(random: Random) extends BalanceDetailGenerator:
+
+  private def randomInRange(range: Range): Int =
+    val start = Math.min(range.start, range.end)
+    val end   = Math.max(range.start, range.end)
+
+    start + random.nextInt((end - start) + 1)
+
+  def generate: BalanceDetail =
+    val pendingDueDate   = PendingDueDate(nextDayInFuture(monthsToAdd = 3))
+    val payableDueDate   = PayableDueDate(nextDayInFuture(monthsToAdd = 6))
+    val overdueAmount    = OverdueAmount(randomInRange(0 to 9999))
+    val payableAmount    = PayableAmount(randomInRange(0 to 9999))
+    val pendingDueAmount = PendingDueAmount(randomInRange(0 to 9999))
+    val totalBalance     = TotalBalance(payableAmount ++ pendingDueAmount ++ overdueAmount)
+
+    BalanceDetail(payableAmount, payableDueDate, pendingDueAmount, pendingDueDate, overdueAmount, totalBalance)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/GenerationStrategy.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/GenerationStrategy.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitstubs.generator
+
+import com.typesafe.config.Config
+import play.api.{ConfigLoader, Configuration}
+
+enum GenerationStrategy:
+  case Faker, Randomize
+
+object GenerationStrategy:
+
+  def loadStrategy(strategyString: String): Option[GenerationStrategy] =
+    GenerationStrategy.values.find(_.toString.toLowerCase == strategyString.toLowerCase)
+
+  implicit val strategyConfigLoader: ConfigLoader[GenerationStrategy] = (config: Config, prefix: String) =>
+    Configuration(config).get[String](prefix) match
+      case "fake"      => Faker
+      case "randomize" => Randomize
+      case other       => throw new IllegalArgumentException(s"Invalid generation strategy: $other")

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/package.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/package.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.saliabilitiessandpitstubs
 
 import com.github.javafaker.Faker
+import uk.gov.hmrc.saliabilitiessandpitstubs.config.AppConfig
 import uk.gov.hmrc.saliabilitiessandpitstubs.time.{FakerExtensions, LocalDateExtensions}
 
 import javax.inject.Inject
@@ -30,5 +31,13 @@ package object generator:
 
   case class DefaultBalanceDetailGeneratorResolver @Inject() ()(using
     faker: BalanceDetailFaker,
-    randomize: BalanceDetailRandomize
+    randomize: BalanceDetailRandomize,
+    config: AppConfig
   ) extends BalanceDetailGeneratorResolver
+      with BalanceDetailGeneratorBackendHeaderCarrierProvider(using config.defaultGenerationHeader)
+
+  case class DefaultBalanceDetailInitialGeneratorResolver @Inject() ()(using
+    faker: BalanceDetailFaker,
+    randomize: BalanceDetailRandomize,
+    config: AppConfig
+  ) extends BalanceDetailInitialGeneratorResolver

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/package.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/generator/package.scala
@@ -16,11 +16,19 @@
 
 package uk.gov.hmrc.saliabilitiessandpitstubs
 
-import uk.gov.hmrc.saliabilitiessandpitstubs.time.LocalDateExtensions
+import com.github.javafaker.Faker
+import uk.gov.hmrc.saliabilitiessandpitstubs.time.{FakerExtensions, LocalDateExtensions}
 
 import javax.inject.Inject
 import scala.util.Random
 
 package object generator:
   case class DefaultBalanceDetailGenerator @Inject() (random: Random)
-      extends BalanceDetailGenerator(using LocalDateExtensions)(random)
+      extends BalanceDetailRandomize(using LocalDateExtensions)(random)
+
+  case class DefaultBalanceDetailFaker @Inject() ()(using faker: Faker) extends BalanceDetailFaker, FakerExtensions
+
+  case class DefaultBalanceDetailGeneratorResolver @Inject() ()(using
+    faker: BalanceDetailFaker,
+    randomize: BalanceDetailRandomize
+  ) extends BalanceDetailGeneratorResolver

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/http/Streamliner.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/http/Streamliner.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitstubs.http
+
+import org.apache.pekko.stream.scaladsl.{Flow, Source}
+import org.apache.pekko.util.ByteString
+import org.apache.pekko.util.ByteString.empty
+import play.api.http.HttpEntity
+import play.api.http.HttpEntity.*
+import play.api.libs.json.Json.stringify
+import play.api.libs.json.{Json, Writes}
+
+import scala.collection.immutable.Iterable
+import scala.concurrent.Future
+import scala.util.Try
+
+trait Streamliner[T]:
+
+  def marschal(iterable: Iterable[T])(implicit tjs: Writes[T]): Streamed =
+    val source = (Source single iterable)
+      .map(Json.toJson(_))
+      .map(jsonArray => ByteString(stringify(jsonArray)))
+      .recover { case e: Exception =>
+        ByteString(s"Error serializing JSON: ${e.getMessage}")
+      }
+      .via((Flow[ByteString] foldAsync empty)((acc, element) => Future fromTry Try(acc ++ element)))
+
+    Streamed(source, None, Some("application/json"))

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/json/JsValidator.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/json/JsValidator.scala
@@ -14,14 +14,9 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.saliabilitiessandpitstubs
+package uk.gov.hmrc.saliabilitiessandpitstubs.json
 
-import uk.gov.hmrc.saliabilitiessandpitstubs.generator.{BalanceDetailGeneratorResolver, BalanceDetailInitialGeneratorResolver, BalanceDetailRandomize}
+import play.api.libs.json.{JsResult, JsValue}
 
-import javax.inject.Inject
-
-package object service:
-  case class DefaultBalanceDetailService @Inject() (
-    generator: BalanceDetailInitialGeneratorResolver,
-    res: BalanceDetailGeneratorResolver
-  ) extends BalanceDetailService(using generator, res)
+trait JsValidator[T]:
+  def validate(json: JsValue): JsResult[T]

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/models/BalanceDetail.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/models/BalanceDetail.scala
@@ -26,15 +26,32 @@ import scala.annotation.targetName
 import scala.collection.immutable.Iterable
 
 case class BalanceDetail(
-  payableAmount: PayableAmount,
-  payableDueDate: PayableDueDate,
-  pendingDueAmount: PendingDueAmount,
-  pendingDueDate: PendingDueDate,
-  overdueAmount: OverdueAmount,
-  totalBalance: TotalBalance
+  payableAmount: Option[PayableAmount] = None,
+  payableDueDate: Option[PayableDueDate] = None,
+  pendingDueAmount: Option[PendingDueAmount] = None,
+  pendingDueDate: Option[PendingDueDate] = None,
+  overdueAmount: Option[OverdueAmount] = None,
+  totalBalance: Option[TotalBalance] = None
 )
 
 object BalanceDetail:
+  def apply(
+    payableAmount: PayableAmount,
+    payableDueDate: PayableDueDate,
+    pendingDueAmount: PendingDueAmount,
+    pendingDueDate: PendingDueDate,
+    overdueAmount: OverdueAmount,
+    totalBalance: TotalBalance
+  ): BalanceDetail =
+    new BalanceDetail(
+      Some(payableAmount),
+      Some(payableDueDate),
+      Some(pendingDueAmount),
+      Some(pendingDueDate),
+      Some(overdueAmount),
+      Some(totalBalance)
+    )
+
   given Format[BalanceDetail] = Json.format[BalanceDetail]
 
   @targetName("UnionOfWriteableIterableBalanceDetail")

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/service/BalanceDetailService.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/service/BalanceDetailService.scala
@@ -16,10 +16,11 @@
 
 package uk.gov.hmrc.saliabilitiessandpitstubs.service
 
-import uk.gov.hmrc.saliabilitiessandpitstubs.generator.BalanceDetailGenerator
-import uk.gov.hmrc.saliabilitiessandpitstubs.models.{BalanceDetail, *}
+import play.api.mvc.{AnyContent, Request}
+import uk.gov.hmrc.saliabilitiessandpitstubs.generator.{BalanceDetailGeneratorResolver, BalanceDetailRandomize}
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.*
 
-trait BalanceDetailService(using generator: BalanceDetailGenerator):
+trait BalanceDetailService(using generator: BalanceDetailRandomize, res: BalanceDetailGeneratorResolver):
 
   private var details: Map[String, BalanceDetail | Seq[BalanceDetail]] = Map(
     "AA000000A" -> generator.generate,
@@ -31,9 +32,10 @@ trait BalanceDetailService(using generator: BalanceDetailGenerator):
   val balanceDetailsByNino: String => Option[BalanceDetail | Seq[BalanceDetail]] = details.get(_: String)
 
   val addOrUpdateBalanceDetail: (String, BalanceDetail) => Unit = (nino: String, balanceDetail: BalanceDetail) =>
-    details = details.get(nino) match
+    details = details get nino match
       case Some(existingDetail: BalanceDetail)       => details + (nino -> Seq(existingDetail, balanceDetail))
       case Some(existingDetails: Seq[BalanceDetail]) => details + (nino -> (existingDetails :+ balanceDetail))
       case None                                      => details + (nino -> balanceDetail)
 
-  val addOrUpdateGeneratedBalanceDetail: String => Unit = addOrUpdateBalanceDetail(_: String, generator.generate)
+  def addOrUpdateGeneratedBalanceDetail(nino: String)(implicit request: Request[AnyContent]): Unit =
+    addOrUpdateBalanceDetail(nino, res.generate(request))

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/service/BalanceDetailService.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/service/BalanceDetailService.scala
@@ -17,10 +17,10 @@
 package uk.gov.hmrc.saliabilitiessandpitstubs.service
 
 import play.api.mvc.{AnyContent, Request}
-import uk.gov.hmrc.saliabilitiessandpitstubs.generator.{BalanceDetailGeneratorResolver, BalanceDetailRandomize}
+import uk.gov.hmrc.saliabilitiessandpitstubs.generator.{BalanceDetailGeneratorResolver, BalanceDetailInitialGeneratorResolver, BalanceDetailRandomize}
 import uk.gov.hmrc.saliabilitiessandpitstubs.models.*
 
-trait BalanceDetailService(using generator: BalanceDetailRandomize, res: BalanceDetailGeneratorResolver):
+trait BalanceDetailService(using generator: BalanceDetailInitialGeneratorResolver, res: BalanceDetailGeneratorResolver):
 
   private var details: Map[String, BalanceDetail | Seq[BalanceDetail]] = Map(
     "AA000000A" -> generator.generate,

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/time/FakerExtensions.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/time/FakerExtensions.scala
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.saliabilitiessandpitstubs
+package uk.gov.hmrc.saliabilitiessandpitstubs.time
 
-import uk.gov.hmrc.saliabilitiessandpitstubs.generator.{BalanceDetailGeneratorResolver, BalanceDetailRandomize}
+import com.github.javafaker.Faker
 
-import javax.inject.Inject
+import java.time.LocalDate.ofInstant
+import java.time.ZoneId.systemDefault
+import java.time.{LocalDate, ZoneId}
+import java.util.concurrent.TimeUnit
 
-package object service:
-  case class DefaultBalanceDetailService @Inject() (
-    generator: BalanceDetailRandomize,
-    res: BalanceDetailGeneratorResolver
-  ) extends BalanceDetailService(using generator, res)
+trait FakerExtensions:
+
+  extension (faker: Faker)
+    def dateInFuture(atMost: Int, unit: TimeUnit): LocalDate =
+      ofInstant((faker.date future (atMost, unit)).toInstant, systemDefault)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/validator/BalanceDetailValidator.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/validator/BalanceDetailValidator.scala
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.saliabilitiessandpitstubs
+package uk.gov.hmrc.saliabilitiessandpitstubs.validator
 
-import uk.gov.hmrc.saliabilitiessandpitstubs.generator.{BalanceDetailGeneratorResolver, BalanceDetailInitialGeneratorResolver, BalanceDetailRandomize}
+import play.api.libs.json.*
+import uk.gov.hmrc.saliabilitiessandpitstubs.json.JsValidator
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 
-import javax.inject.Inject
+class BalanceDetailValidator(val requiredFields: Set[String]) extends JsValidator[BalanceDetail]:
 
-package object service:
-  case class DefaultBalanceDetailService @Inject() (
-    generator: BalanceDetailInitialGeneratorResolver,
-    res: BalanceDetailGeneratorResolver
-  ) extends BalanceDetailService(using generator, res)
+  override def validate(json: JsValue): JsResult[BalanceDetail] =
+    json.validate[JsObject].flatMap { obj =>
+      if requiredFields.subsetOf(obj.keys) then obj.validate[BalanceDetail]
+      else JsError(s"Missing required fields: ${requiredFields.diff(obj.keys).mkString(", ")}")
+    }

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/validator/ModelBasedBalanceDetailValidator.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/validator/ModelBasedBalanceDetailValidator.scala
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.saliabilitiessandpitstubs
+package uk.gov.hmrc.saliabilitiessandpitstubs.validator
 
-import uk.gov.hmrc.saliabilitiessandpitstubs.generator.{BalanceDetailGeneratorResolver, BalanceDetailInitialGeneratorResolver, BalanceDetailRandomize}
+import play.api.libs.json.{JsResult, JsValue}
+import uk.gov.hmrc.saliabilitiessandpitstubs.json.JsValidator
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 
-import javax.inject.Inject
+class ModelBasedBalanceDetailValidator extends JsValidator[BalanceDetail]:
 
-package object service:
-  case class DefaultBalanceDetailService @Inject() (
-    generator: BalanceDetailInitialGeneratorResolver,
-    res: BalanceDetailGeneratorResolver
-  ) extends BalanceDetailService(using generator, res)
+  override def validate(json: JsValue): JsResult[BalanceDetail] =
+    json.validate[BalanceDetail]

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -62,8 +62,22 @@ feature-toggles {
   new-auth-check-enabled = true
 }
 
-random {
-  seed = 42
+generator {
+    random {
+      seed = 42
+    }
+    default = "fake"
+    request {
+        header = "X-USE-STRATEGY-GENERATION"
+    }
+}
+
+
+validation {
+    balance {
+        enable = true
+        fields = ["pendingDueAmount", "overdueAmount", "payableAmount"]
+    }
 }
 
 microservice {

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,6 +9,7 @@ object AppDependencies {
   val compile = Seq(
     "uk.gov.hmrc"             %% "bootstrap-backend-play-30"  % bootstrapVersion,
     "org.apache.pekko"        %% "pekko-stream"               % PekkoVersion,
+    "com.github.javafaker"    % "javafaker"                   % "1.0.2"
   )
 
   val test = Seq(

--- a/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.saliabilitiessandpitstubs.controllers
 
+import com.github.javafaker.Faker
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import org.scalatestplus.mockito.MockitoSugar.mock
@@ -23,23 +24,33 @@ import play.api.http.Status
 import play.api.mvc.ControllerComponents
 import play.api.test.Helpers.*
 import play.api.test.{FakeRequest, Helpers}
+import uk.gov.hmrc.saliabilitiessandpitstubs.config.AppConfig
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.AuthorizationActionFilter.OpenAuthAction
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.DefaultOpenAuthAction
-import uk.gov.hmrc.saliabilitiessandpitstubs.generator.DefaultBalanceDetailGenerator
+import uk.gov.hmrc.saliabilitiessandpitstubs.generator.{BalanceDetailFaker, BalanceDetailRandomize, DefaultBalanceDetailFaker, DefaultBalanceDetailGenerator, DefaultBalanceDetailInitialGeneratorResolver}
+import uk.gov.hmrc.saliabilitiessandpitstubs.json.JsValidator
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.{BalanceDetailService, DefaultBalanceDetailService}
+import uk.gov.hmrc.saliabilitiessandpitstubs.validator.ModelBasedBalanceDetailValidator
 
 import scala.concurrent.ExecutionContext
 import scala.util.Random
 
 class BalanceControllerSpec extends AnyWordSpec with Matchers {
 
-  private val fakeRequest                      = FakeRequest("GET", "/AA000000A")
-  private val components: ControllerComponents = Helpers.stubControllerComponents()
-  given random: Random                         = new Random()
-  given executionContext: ExecutionContext     = components.executionContext
-  given auth: OpenAuthAction                   = new DefaultOpenAuthAction(executionContext)
-  given service: BalanceDetailService          = DefaultBalanceDetailService(DefaultBalanceDetailGenerator(random), mock)
-  private val controller                       = new BalanceController(components)
+  private val fakeRequest                              = FakeRequest("GET", "/AA000000A")
+  private val components: ControllerComponents         = Helpers.stubControllerComponents()
+  given random: Random                                 = new Random()
+  given faker: Faker                                   = new Faker()
+  given balanceDetailFaker: BalanceDetailFaker         = new DefaultBalanceDetailFaker
+  given balanceDetailRandomize: BalanceDetailRandomize = DefaultBalanceDetailGenerator(random)
+  given app: AppConfig                                 = mock
+  given executionContext: ExecutionContext             = components.executionContext
+  given jsValidator: JsValidator[BalanceDetail]        = new ModelBasedBalanceDetailValidator()
+  given auth: OpenAuthAction                           = new DefaultOpenAuthAction(executionContext)
+  given service: BalanceDetailService                  =
+    DefaultBalanceDetailService(new DefaultBalanceDetailInitialGeneratorResolver, mock)
+  private val controller                               = new BalanceController(components)
 
   "GET /balance/AA000000A" should {
     "return 200" in {

--- a/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.saliabilitiessandpitstubs.controllers
 
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.mockito.MockitoSugar.mock
 import play.api.http.Status
 import play.api.mvc.ControllerComponents
 import play.api.test.Helpers.*
@@ -37,7 +38,7 @@ class BalanceControllerSpec extends AnyWordSpec with Matchers {
   given random: Random                         = new Random()
   given executionContext: ExecutionContext     = components.executionContext
   given auth: OpenAuthAction                   = new DefaultOpenAuthAction(executionContext)
-  given service: BalanceDetailService          = DefaultBalanceDetailService(DefaultBalanceDetailGenerator(random))
+  given service: BalanceDetailService          = DefaultBalanceDetailService(DefaultBalanceDetailGenerator(random), mock)
   private val controller                       = new BalanceController(components)
 
   "GET /balance/AA000000A" should {


### PR DESCRIPTION
This pull request introduces a new `BalanceDetailGeneratorResolver` component that provides flexible balance detail generation using the Faker library. This enhancement offers greater control and customization for testing and development purposes. This now allows users to select between different generation strategies using a header parameter.
