### PR TITLE
[DI-296]: Create new network simulation strategies

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/AppConfig.scala
@@ -19,16 +19,20 @@ package uk.gov.hmrc.saliabilitiessandpitstubs.config
 import play.api.Configuration
 import uk.gov.hmrc.saliabilitiessandpitstubs.generator.GenerationStrategy
 import uk.gov.hmrc.saliabilitiessandpitstubs.time.TimeStrategy
+import uk.gov.hmrc.saliabilitiessandpitstubs.utils.DelaySimulatorStrategy
 
 import javax.inject.Inject
 
 class AppConfig @Inject() (config: Configuration):
-  val appName: String                           = config.get[String]("appName")
-  val bearerAuthorisationEnabled: Boolean       = config.get[Boolean]("feature-toggles.new-auth-check-enabled")
-  val randomSeed: Option[Int]                   = config.get[Option[Int]]("generator.random.seed")
-  val defaultGenerator: GenerationStrategy      = config.get[GenerationStrategy]("generator.default")
-  val timeStrategy: TimeStrategy                = config.get[TimeStrategy]("generator.time")
-  val currentDate: String                       = config.get[String]("generator.date")
-  val defaultGenerationHeader: String           = config.get[String]("generator.request.header")
-  val balanceDetailValidatorFields: Seq[String] = config.get[Seq[String]]("validation.balance.fields")
-  val balanceDetailValidationEnable: Boolean    = config.get[Boolean]("validation.balance.enable")
+  val appName: String                                = config.get[String]("appName")
+  val bearerAuthorisationEnabled: Boolean            = config.get[Boolean]("feature-toggles.new-auth-check-enabled")
+  val randomSeed: Option[Int]                        = config.get[Option[Int]]("generator.random.seed")
+  val defaultGenerator: GenerationStrategy           = config.get[GenerationStrategy]("generator.default")
+  val simulatorStrategy: DelaySimulatorStrategy      = config.get[DelaySimulatorStrategy]("generator.network.strategy")
+  val networkConditionConfig: NetworkConditionConfig =
+    config.get[NetworkConditionConfig]("generator.network.failureProbability")
+  val timeStrategy: TimeStrategy                     = config.get[TimeStrategy]("generator.time")
+  val currentDate: String                            = config.get[String]("generator.date")
+  val defaultGenerationHeader: String                = config.get[String]("generator.request.header")
+  val balanceDetailValidatorFields: Seq[String]      = config.get[Seq[String]]("validation.balance.fields")
+  val balanceDetailValidationEnable: Boolean         = config.get[Boolean]("validation.balance.enable")

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Module.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Module.scala
@@ -27,6 +27,7 @@ import uk.gov.hmrc.saliabilitiessandpitstubs.repository.BalanceDetailRepository
 import uk.gov.hmrc.saliabilitiessandpitstubs.repository.InMemoryBalanceDetailRepository
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.{BalanceDetailService, DefaultBalanceDetailService}
 import uk.gov.hmrc.saliabilitiessandpitstubs.time.{DefaultFutureDateGenerator, FutureDateGenerator, SystemLocalDate}
+import uk.gov.hmrc.saliabilitiessandpitstubs.utils.*
 
 import scala.util.Random
 
@@ -41,8 +42,18 @@ class Module extends AbstractModule {
     bind(classOf[BalanceDetailFaker]).to(classOf[DefaultBalanceDetailFaker]).asEagerSingleton()
     bind(classOf[BalanceDetailService]).to(classOf[DefaultBalanceDetailService]).asEagerSingleton()
     bind(classOf[FutureDateGenerator]).to(classOf[DefaultFutureDateGenerator]).asEagerSingleton()
+    bind(classOf[DiscreteDelayDistributionStrategy])
+      .to(classOf[DefaultDiscreteDelayDistributionStrategy])
+      .asEagerSingleton()
+    bind(classOf[LogDelayDistributionStrategy]).to(classOf[DefaultLogDelayDistributionStrategy]).asEagerSingleton()
+    bind(classOf[NormalDelayDistributionStrategy])
+      .to(classOf[DefaultNormalDelayDistributionStrategy])
+      .asEagerSingleton()
+    bind(classOf[AlwaysSuccessfulSimulatorStrategy])
+      .toInstance(AlwaysSuccessfulSimulatorStrategy)
     bind(classOf[BalanceDetailRepository]).toInstance(InMemoryBalanceDetailRepository)
     bind(classOf[AuthorizationActionFilter]).toProvider(classOf[AuthActionProvider]).asEagerSingleton()
+    bind(classOf[DelaySimulator]).toProvider(classOf[DelaySimulatorProvider]).asEagerSingleton()
     bind(classOf[SystemLocalDate]).toProvider(classOf[LocalDateProvider]).asEagerSingleton()
     bind(classOf[BalanceDetailRandomize]).to(classOf[DefaultBalanceDetailGenerator]).asEagerSingleton()
     bind(classOf[BalanceDetailInitialGeneratorResolver])

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/NetworkConditionConfig.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/NetworkConditionConfig.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitstubs.config
+
+import com.typesafe.config.Config
+import play.api.{ConfigLoader, Configuration}
+
+import scala.language.implicitConversions
+
+case class NetworkConditionConfig(
+  failureProbability: Double,
+  randomDelayProbability: Double,
+  throttlingProbability: Double,
+  timeoutProbability: Double,
+  standardDeviation: Double,
+  mean: Double
+)
+
+object NetworkConditionConfig:
+
+  given ConfigLoader[NetworkConditionConfig] with
+    def load(config: Config, prefix: String): NetworkConditionConfig =
+      val serviceConfig                  = Configuration(config).get[Configuration](prefix)
+      val failureProbability: Double     = serviceConfig.get[String]("failure").toDouble
+      val randomDelayProbability: Double = serviceConfig.get[String]("randomDelay").toDouble
+      val throttlingProbability: Double  = serviceConfig.get[String]("throttling").toDouble
+      val timeoutProbability: Double     = serviceConfig.get[String]("timeout").toDouble
+      val standardDeviation: Double      = serviceConfig.get[String]("standardDeviation").toDouble
+      val mean: Double                   = serviceConfig.get[String]("mean").toDouble
+
+      NetworkConditionConfig(
+        failureProbability,
+        randomDelayProbability,
+        throttlingProbability,
+        timeoutProbability,
+        standardDeviation,
+        mean
+      )

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceController.scala
@@ -27,18 +27,23 @@ import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
 import uk.gov.hmrc.saliabilitiessandpitstubs.utils.DelaySimulator
 
 import javax.inject.Inject
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Random
 
 class BalanceController @Inject() (
   val controllerComponents: ControllerComponents
-)(using AuthorizationActionFilter, BalanceDetailService, Random, ExecutionContext, JsValidator[BalanceDetail])
-    extends BalanceActions,
+)(using
+  AuthorizationActionFilter,
+  BalanceDetailService,
+  Random,
+  ExecutionContext,
+  JsValidator[BalanceDetail],
+  DelaySimulator
+) extends BalanceActions,
       SaveNewLiability,
       SaveGeneratedLiability,
       DeleteLiabilityAction,
       ReplaceExistingBalanceDetailAction,
       Streamliner[BalanceDetail],
       BackendBaseController,
-      DelaySimulator,
       Logging

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/BalanceActions.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/action/BalanceActions.scala
@@ -25,11 +25,15 @@ import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
 import uk.gov.hmrc.saliabilitiessandpitstubs.utils.DelaySimulator
 
-private[controllers] trait BalanceActions(using auth: AuthorizationActionFilter, service: BalanceDetailService):
-  self: BaseController & DelaySimulator & Streamliner[BalanceDetail] =>
+private[controllers] trait BalanceActions(using
+  auth: AuthorizationActionFilter,
+  service: BalanceDetailService,
+  network: DelaySimulator
+):
+  self: BaseController & Streamliner[BalanceDetail] =>
 
   def getBalanceByNino(nino: String): Action[AnyContent] = (Action andThen auth).async { implicit request: Request[_] =>
-    simulateNetworkConditions {
+    network.simulateNetworkConditions {
       service.balanceDetailsByNino(nino) match
         case Some(balanceDetails: Seq[BalanceDetail]) => Ok.sendEntity(marschal(balanceDetails))
         case Some(balance: BalanceDetail)             => Ok(balance)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/AlwaysSuccessfulSimulatorStrategy.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/AlwaysSuccessfulSimulatorStrategy.scala
@@ -17,7 +17,8 @@
 package uk.gov.hmrc.saliabilitiessandpitstubs.utils
 
 import scala.concurrent.Future
+import scala.concurrent.Future.successful
 
-trait DelaySimulator:
+trait AlwaysSuccessfulSimulatorStrategy extends DelaySimulator:
 
-  def simulateNetworkConditions[T](result: T): Future[T]
+  override def simulateNetworkConditions[T](result: T): Future[T] = successful(result)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/DelaySimulatorStrategy.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/DelaySimulatorStrategy.scala
@@ -16,8 +16,18 @@
 
 package uk.gov.hmrc.saliabilitiessandpitstubs.utils
 
-import scala.concurrent.Future
+import com.typesafe.config.Config
+import play.api.{ConfigLoader, Configuration}
 
-trait DelaySimulator:
+enum DelaySimulatorStrategy:
+  case Log, Normal, Discrete, None
 
-  def simulateNetworkConditions[T](result: T): Future[T]
+object DelaySimulatorStrategy:
+
+  implicit val strategyConfigLoader: ConfigLoader[DelaySimulatorStrategy] = (config: Config, prefix: String) =>
+    Configuration(config).get[String](prefix) match
+      case "log"      => DelaySimulatorStrategy.Log
+      case "normal"   => DelaySimulatorStrategy.Normal
+      case "discrete" => DelaySimulatorStrategy.Discrete
+      case "none"     => DelaySimulatorStrategy.None
+      case other      => throw new IllegalArgumentException(s"Invalid network strategy: $other")

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/DelayStrategy.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/DelayStrategy.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitstubs.utils
+
+import org.apache.pekko
+import org.apache.pekko.*
+import org.apache.pekko.actor.*
+import org.apache.pekko.pattern.after
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.Future.*
+import scala.concurrent.duration.*
+import scala.concurrent.{ExecutionContext, Future, TimeoutException}
+import scala.util.Random
+
+trait DelayStrategy(using random: Random, executionContext: ExecutionContext) {
+
+  def simulateRandomDelay[T](result: T, maxDelay: FiniteDuration = 1000.millis): Future[T] =
+    val randomDelay = FiniteDuration(random.between(50, maxDelay.toMillis), TimeUnit.MILLISECONDS)
+    after(randomDelay, using = ActorSystem().scheduler)(successful(result))
+
+  def simulateFailureWithDelay[T](result: T, delay: FiniteDuration = 1.seconds, failureRate: Double = 0.5): Future[T] =
+    if random.nextDouble < failureRate then
+      after(delay, using = ActorSystem().scheduler)(failed(new RuntimeException("Simulated failure")))
+    else after(delay, using = ActorSystem().scheduler)(successful(result))
+
+  def simulateThrottling[T](result: T, throttleDuration: FiniteDuration = 3.seconds): Future[T] =
+    after(throttleDuration, using = ActorSystem().scheduler)(successful(result))
+
+  def simulateTimeout[T](timeoutDuration: FiniteDuration = 10.seconds): Future[T] =
+    after(timeoutDuration, using = ActorSystem().scheduler)(failed(new TimeoutException("Simulated timeout")))
+
+}

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/DiscreteDelayDistributionStrategy.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/DiscreteDelayDistributionStrategy.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitstubs.utils
+
+import uk.gov.hmrc.saliabilitiessandpitstubs.config.NetworkConditionConfig
+
+import scala.concurrent.Future
+import scala.concurrent.Future.successful
+import scala.util.Random
+
+trait DiscreteDelayDistributionStrategy(using random: Random, config: NetworkConditionConfig) extends DelaySimulator:
+  self: DelayStrategy =>
+
+  override def simulateNetworkConditions[T](result: T): Future[T] = random.nextDouble() match
+    case p if p < config.failureProbability                                                                => simulateFailureWithDelay(result)
+    case p if p < config.failureProbability + config.randomDelayProbability                                => simulateRandomDelay(result)
+    case p if p < config.failureProbability + config.randomDelayProbability + config.throttlingProbability =>
+      simulateThrottling(result)
+    case p
+        if p < config.failureProbability + config.randomDelayProbability + config.throttlingProbability + config.timeoutProbability =>
+      simulateTimeout()
+    case _                                                                                                 => successful(result)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/LogDelayDistributionStrategy.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/LogDelayDistributionStrategy.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitstubs.utils
+
+import uk.gov.hmrc.saliabilitiessandpitstubs.config.NetworkConditionConfig
+
+import scala.concurrent.Future
+import scala.concurrent.Future.successful
+import scala.math.{exp, max}
+import scala.util.Random
+
+trait LogDelayDistributionStrategy(using random: Random, config: NetworkConditionConfig) extends DelaySimulator:
+  self: DelayStrategy =>
+
+  override def simulateNetworkConditions[T](result: T): Future[T] =
+    val logNormalValue = random.nextGaussian
+    val probability    = exp(logNormalValue * config.standardDeviation + config.mean)
+
+    math min (max(probability, 0.0), 1.0) match
+      case p if p < config.failureProbability                                                                => simulateFailureWithDelay(result)
+      case p if p < config.failureProbability + config.randomDelayProbability                                => simulateRandomDelay(result)
+      case p if p < config.failureProbability + config.randomDelayProbability + config.throttlingProbability =>
+        simulateThrottling(result)
+      case p
+          if p < config.failureProbability + config.randomDelayProbability + config.throttlingProbability + config.timeoutProbability =>
+        simulateTimeout()
+      case _                                                                                                 => successful(result)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/NormalDelayDistributionStrategy.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/NormalDelayDistributionStrategy.scala
@@ -17,7 +17,15 @@
 package uk.gov.hmrc.saliabilitiessandpitstubs.utils
 
 import scala.concurrent.Future
+import scala.concurrent.Future.successful
+import scala.util.Random
 
-trait DelaySimulator:
+trait NormalDelayDistributionStrategy(using random: Random) extends DelaySimulator:
+  self: DelayStrategy =>
 
-  def simulateNetworkConditions[T](result: T): Future[T]
+  override def simulateNetworkConditions[T](result: T): Future[T] = random.nextGaussian() match
+    case p if p < -1.0 => simulateFailureWithDelay(result)
+    case p if p < -0.5 => simulateRandomDelay(result)
+    case p if p < 0.0  => simulateThrottling(result)
+    case p if p < 1.0  => simulateTimeout()
+    case _             => successful(result)

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/package.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/utils/package.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitstubs
+
+import com.google.inject.Inject
+import uk.gov.hmrc.saliabilitiessandpitstubs.config.{AppConfig, NetworkConditionConfig}
+
+import scala.concurrent.ExecutionContext
+import scala.util.Random
+
+package object utils:
+  object AlwaysSuccessfulSimulatorStrategy extends AlwaysSuccessfulSimulatorStrategy
+  class DefaultDiscreteDelayDistributionStrategy @Inject() (val appConfig: AppConfig)(using
+    random: Random,
+    ex: ExecutionContext
+  ) extends DiscreteDelayDistributionStrategy(using random, appConfig.networkConditionConfig)
+      with DelayStrategy
+  class DefaultLogDelayDistributionStrategy @Inject() (val appConfig: AppConfig)(using
+    random: Random,
+    ex: ExecutionContext
+  ) extends LogDelayDistributionStrategy(using random, appConfig.networkConditionConfig)
+      with DelayStrategy
+  class DefaultNormalDelayDistributionStrategy @Inject() ()(using Random, ExecutionContext)
+      extends NormalDelayDistributionStrategy
+      with DelayStrategy

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,5 +6,5 @@ POST       /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.cont
 DELETE     /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.deleteBalanceDetail(nino: String)
 PATCH      /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.replaceExistingBalanceDetailAction(nino: String)
 
-GET        /stub/                     uk.gov.hmrc.saliabilitiessandpitstubs.controllers.WizardController.cometString()
+GET        /stub                      uk.gov.hmrc.saliabilitiessandpitstubs.controllers.WizardController.cometString()
 POST       /stub/submit               uk.gov.hmrc.saliabilitiessandpitstubs.controllers.WizardController.submit()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -66,6 +66,18 @@ generator {
     random {
       seed = 42
     }
+    network {
+       strategy = "discrete"
+
+       failureProbability {
+        failure = 0.15
+        randomDelay = 0.15
+        throttling = 0.15
+        timeout = 0.15
+        standardDeviation = 0.73
+        mean = 0.37
+       }
+    }
     time = "fake"
     date = "1993-11-13"
     default = "fake"

--- a/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceControllerSpec.scala
@@ -34,6 +34,7 @@ import uk.gov.hmrc.saliabilitiessandpitstubs.models.{BalanceDetail, *}
 import uk.gov.hmrc.saliabilitiessandpitstubs.repository.{BalanceDetailRepository, InMemoryBalanceDetailRepository}
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.{BalanceDetailService, DefaultBalanceDetailService}
 import uk.gov.hmrc.saliabilitiessandpitstubs.time.{DefaultFutureDateGenerator, FutureDateGenerator, StubbedSystemLocalDate, SystemLocalDate}
+import uk.gov.hmrc.saliabilitiessandpitstubs.utils.{AlwaysSuccessfulSimulatorStrategy, DelaySimulator}
 import uk.gov.hmrc.saliabilitiessandpitstubs.validator.ModelBasedBalanceDetailValidator
 
 import scala.concurrent.ExecutionContext
@@ -49,6 +50,7 @@ class BalanceControllerSpec extends AnyWordSpec with Matchers {
   given auth: OpenAuthAction                   = DefaultOpenAuthAction(executionContext)
   given BalanceDetailGeneratorResolver         = mock
   given repo: BalanceDetailRepository          = InMemoryBalanceDetailRepository
+  given DelaySimulator                         = AlwaysSuccessfulSimulatorStrategy
   given BalanceDetailService                   = DefaultBalanceDetailService()
   private val controller                       = BalanceController(components)
 


### PR DESCRIPTION
This pull request introduces several new network condition strategies to improve the realism and flexibility of the simulation process. 

The following strategies have been added:

- DiscreteDelayDistributionStrategy: Simulates discrete delays based on a predefined distribution.
- AlwaysSuccessfulSimulatorStrategy: Always returns a successful result without introducing any delays or errors.
- NormalDelayDistributionStrategy: Simulates normally distributed delays.
- LogDelayDistributionStrategy: Simulates log-normally distributed delays.