### PR TITLE
[DI-296]: Split BalanceController into 2 controllers 1 for read one f…

### DIFF
--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Module.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/config/Module.scala
@@ -18,7 +18,7 @@ package uk.gov.hmrc.saliabilitiessandpitstubs.config
 
 import com.github.javafaker.Faker
 import com.google.inject.{AbstractModule, TypeLiteral}
-import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController
+import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.{BalanceCommandController, BalanceQueryController}
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.AuthorizationActionFilter
 import uk.gov.hmrc.saliabilitiessandpitstubs.generator.*
 import uk.gov.hmrc.saliabilitiessandpitstubs.json.JsValidator
@@ -37,7 +37,8 @@ class Module extends AbstractModule {
     bind(classOf[Faker]).asEagerSingleton()
     bind(classOf[DatabaseInitializer]).asEagerSingleton()
     bind(classOf[AppConfig]).asEagerSingleton()
-    bind(classOf[BalanceController]).asEagerSingleton()
+    bind(classOf[BalanceQueryController]).asEagerSingleton()
+    bind(classOf[BalanceCommandController]).asEagerSingleton()
     bind(classOf[Random]).toProvider(classOf[RandomProvider]).asEagerSingleton()
     bind(classOf[BalanceDetailFaker]).to(classOf[DefaultBalanceDetailFaker]).asEagerSingleton()
     bind(classOf[BalanceDetailService]).to(classOf[DefaultBalanceDetailService]).asEagerSingleton()

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceCommandController.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceCommandController.scala
@@ -18,31 +18,26 @@ package uk.gov.hmrc.saliabilitiessandpitstubs.controllers
 
 import org.apache.pekko.stream.Materializer
 import play.api.Logging
-import play.api.mvc.*
+import play.api.mvc.ControllerComponents
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendBaseController
 import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.*
 import uk.gov.hmrc.saliabilitiessandpitstubs.http.{FileStreamliner, Streamliner}
 import uk.gov.hmrc.saliabilitiessandpitstubs.json.JsValidator
 import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
 import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
-import uk.gov.hmrc.saliabilitiessandpitstubs.utils.DelaySimulator
 
 import javax.inject.Inject
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Random
+import scala.concurrent.ExecutionContext
 
-class BalanceController @Inject() (
+class BalanceCommandController @Inject() (
   val controllerComponents: ControllerComponents
 )(using
-  AuthorizationActionFilter,
-  BalanceDetailService,
-  Random,
+  Materializer,
   ExecutionContext,
-  JsValidator[BalanceDetail],
-  DelaySimulator,
-  Materializer
-) extends BalanceActions,
-      SaveNewLiability,
+  BalanceDetailService,
+  AuthorizationActionFilter,
+  JsValidator[BalanceDetail]
+) extends SaveNewLiability,
       SaveNewLiabilityFromFileAction,
       FileStreamliner[BalanceDetail],
       SaveGeneratedLiability,

--- a/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceQueryController.scala
+++ b/app/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceQueryController.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.saliabilitiessandpitstubs.controllers
+
+import play.api.Logging
+import play.api.mvc.ControllerComponents
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendBaseController
+import uk.gov.hmrc.saliabilitiessandpitstubs.controllers.action.{AuthorizationActionFilter, BalanceActions}
+import uk.gov.hmrc.saliabilitiessandpitstubs.http.{FileStreamliner, Streamliner}
+import uk.gov.hmrc.saliabilitiessandpitstubs.json.JsValidator
+import uk.gov.hmrc.saliabilitiessandpitstubs.models.BalanceDetail
+import uk.gov.hmrc.saliabilitiessandpitstubs.service.BalanceDetailService
+import uk.gov.hmrc.saliabilitiessandpitstubs.utils.DelaySimulator
+
+import javax.inject.Inject
+
+class BalanceQueryController @Inject() (
+  val controllerComponents: ControllerComponents
+)(using
+  DelaySimulator,
+  BalanceDetailService,
+  AuthorizationActionFilter,
+  JsValidator[BalanceDetail]
+) extends BalanceActions,
+      FileStreamliner[BalanceDetail],
+      Streamliner[BalanceDetail],
+      BackendBaseController,
+      Logging

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -1,11 +1,11 @@
 # microservice specific routes
 
-GET        /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.getBalanceByNino(nino: String)
-PUT        /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.saveNewBalanceByNino(nino: String)
-POST       /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.saveGeneratedBalanceByNino(nino: String)
-DELETE     /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.deleteBalanceDetail(nino: String)
-PATCH      /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.replaceExistingBalanceDetailAction(nino: String)
-POST       /balance/fromfile/:nino     uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceController.uploadBalances(nino: String)
+GET        /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceQueryController.getBalanceByNino(nino: String)
+PUT        /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceCommandController.saveNewBalanceByNino(nino: String)
+POST       /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceCommandController.saveGeneratedBalanceByNino(nino: String)
+DELETE     /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceCommandController.deleteBalanceDetail(nino: String)
+PATCH      /balance/:nino             uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceCommandController.replaceExistingBalanceDetailAction(nino: String)
+POST       /balance/fromfile/:nino     uk.gov.hmrc.saliabilitiessandpitstubs.controllers.BalanceCommandController.uploadBalances(nino: String)
 
 
 GET        /stub                      uk.gov.hmrc.saliabilitiessandpitstubs.controllers.WizardController.cometString()

--- a/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceQueryControllerSpec.scala
+++ b/test/uk/gov/hmrc/saliabilitiessandpitstubs/controllers/BalanceQueryControllerSpec.scala
@@ -41,7 +41,7 @@ import uk.gov.hmrc.saliabilitiessandpitstubs.validator.ModelBasedBalanceDetailVa
 import scala.concurrent.ExecutionContext
 import scala.util.Random
 
-class BalanceControllerSpec extends AnyWordSpec with Matchers {
+class BalanceQueryControllerSpec extends AnyWordSpec with Matchers {
 
   private val fakeRequest                      = FakeRequest("GET", "/AA000000A")
   private val components: ControllerComponents = Helpers.stubControllerComponents()
@@ -54,7 +54,7 @@ class BalanceControllerSpec extends AnyWordSpec with Matchers {
   given repo: BalanceDetailRepository          = InMemoryBalanceDetailRepository
   given DelaySimulator                         = AlwaysSuccessfulSimulatorStrategy
   given BalanceDetailService                   = DefaultBalanceDetailService()
-  private val controller                       = BalanceController(components)
+  private val controller                       = BalanceQueryController(components)
 
   "GET /balance/AA000000A" should {
     "return 200" in {


### PR DESCRIPTION
Just splitting the `BalanceController` into `BalanceCommandController` and `BalanceQueryController` to achieve clean separation of responsibilities:
- `Commands`: Handle create, update, and delete operations.
- `Queries`: Handle read-only operations, like fetching and more in the future