### PR TITLE
[DI-320]: Turn simulated failures off

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -70,12 +70,12 @@ generator {
        strategy = "discrete"
 
        failureProbability {
-        failure = 0.15
-        randomDelay = 0.15
-        throttling = 0.15
-        timeout = 0.15
-        standardDeviation = 0.73
-        mean = 0.37
+        failure = 0
+        randomDelay = 0
+        throttling = 0
+        timeout = 0
+        standardDeviation = 0
+        mean = 0
        }
     }
     time = "fake"


### PR DESCRIPTION
Simulated failures will be off by default to not impact testing efforts.